### PR TITLE
autostart fix for repo name change

### DIFF
--- a/autostart/startupdemo
+++ b/autostart/startupdemo
@@ -11,6 +11,6 @@ raspi-gpio set 33 dl  # drive low to allow Myriad X to run
 echo Booting DepthAI
 echo Loading Start-up Demo Application...
 sleep 1
-cd /home/pi/Desktop/depthai-python-extras
+cd /home/pi/Desktop/depthai
 python3 test.py
 sleep 60


### PR DESCRIPTION
Simple change here, accompanied by a change in /home/pi/.config/autostart/runai.desktop in Raspbian, which will need to be updated manually for users who have an existing uSD with the old depthai-python-extras repo. All future images on uSDs that ship from Luxonis will have this change.