### PR TITLE
Update calibrate.py

### DIFF
--- a/calibrate.py
+++ b/calibrate.py
@@ -126,8 +126,7 @@ class Main:
         self.args = vars(parse_args())
         self.config = {
             'streams':
-                ['left', 'right'] if not on_embedded else
-                [{'name': 'left', "max_fps": 10.0}, {'name': 'right', "max_fps": 10.0}],
+                ['left', 'right'],
             'depth':
                 {
                     'calibration_file': consts.resource_paths.calib_fpath,


### PR DESCRIPTION
Limiting the framerate results in getting frames that are sometimes not in sync.  

So I removed the 10FPS option on embedded for now until we figure out a way to not cause the frames to sometimes be out of sync.

Seems to solve #98 