### PR TITLE
Python3 shebang line; executable permission for python scripts

### DIFF
--- a/calibrate.py
+++ b/calibrate.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import platform
 from contextlib import contextmanager
 

--- a/calibrate_and_test.py
+++ b/calibrate_and_test.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import os
 import signal
 import subprocess

--- a/depthai.py
+++ b/depthai.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import sys
 from time import time
 from time import sleep

--- a/depthai_supervisor.py
+++ b/depthai_supervisor.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 #process watchdog, used to recover depthai.py 
 #on any userspace error in depthai.py (segfault for example)
 import os


### PR DESCRIPTION
To avoid problems with wrong environment/python version this PR adds possibility to run scripts with any of the following commands:
python depthai.py
python3 depthai.py
./depthai.py
Tested on Linux.