### PR TITLE
Add back time.monotonic import

### DIFF
--- a/depthai.py
+++ b/depthai.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import platform
 import os
 import subprocess
-from time import time, sleep
+from time import time, sleep, monotonic
 
 import cv2
 import numpy as np


### PR DESCRIPTION
`from time import monotonic` got somehow deleted when PR https://github.com/luxonis/depthai/pull/106 was merged.
Adding it back, to fix the crash in the python script.