### PR TITLE
add ability to upload to PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,2 +1,24 @@
-from setuptools import setup
-setup(name='depthai_extras')
+import setuptools
+
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
+setuptools.setup(
+    name="depthai",
+    version="0.0.3",
+    author="Luxonis",
+    author_email="brandon@luxonis.com",
+    description="DepthAI Python API",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/luxonis/depthai",
+    py_modules=["depthai"],
+    packages=[''],
+    package_data={'': ['*.so', '*.cmd']},
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+    ],
+    python_requires='>=3.5',
+)


### PR DESCRIPTION
Added ability for the users to install depthAI API via PyPi

Currently, uploaded a test version to test PyPi to verify if it works - here's the link https://test.pypi.org/project/depthai/

Created also user `luxonis` on PyPi, can share password on DM on slack. 
If this will be merged, I'll create a `release` branch and then setup CI/CD on GitLab to automatically upload a new version to PyPi after merge to release

Tested on a new venv, did
```
python3 -m pip install opencv-python
python3 -m pip install -i https://test.pypi.org/simple/ depthai
```

And ran the following script - https://gist.github.com/VanDavv/8961c1458271f5c25e22d165ee4415c6

```
python3 depthai-minimal.py
```

And was able to get the desired output
![Screenshot_2020-05-28_11-22-54](https://user-images.githubusercontent.com/5244214/83123865-bac25e80-a0d5-11ea-97de-66db0af0192e.png)
