### PR TITLE
Update requirements.txt for raspberry pi builds

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 numpy==1.18.3
-opencv-python==4.2.0.34
-requests
+opencv-python>4
+requests==2.24.0


### PR DESCRIPTION
Currently, when trying to install requirements using `requirements.txt` file on Raspberry, it fails, since specified version is not available in Raspbian, example below:

```
pi@raspberrypi:~ $ pip3 install opencv-python==4.2.0.34
Looking in indexes: https://pypi.org/simple, https://www.piwheels.org/simple
Collecting opencv-python==4.2.0.34
  Could not find a version that satisfies the requirement opencv-python==4.2.0.34 (from versions: 3.4.2.16, 3.4.2.17, 3.4.3.18, 3.4.4.19, 3.4.6.27, 3.4.7.28, 4.0.1.24, 4.1.0.25, 4.1.1.26)
No matching distribution found for opencv-python==4.2.0.34
```

We can fix this, by not specifying exact version of `opencv-python` but minimum required version - and in our case we rely on OpenCV version 4.
So simply changing `opencv-python==4.2.0.34` to `opencv-python>4` fixes the issue and always installs latest available version during installation, like below:

```
pi@raspberrypi:~ $ pip3 install opencv-python>4
pi@raspberrypi:~ $ pip3 freeze | grep opencv-python
opencv-python==4.1.1.26
```

Also, fixed requests version (and tested that it works on RPi)