### PR TITLE
Python command line autocomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,21 @@ __Documentation is available at [https://docs.luxonis.com](https://docs.luxonis.
 
 ## Python modules
 
-DepthAI requites [numpy](https://numpy.org/) and [opencv-python](https://pypi.org/project/opencv-python/). To get the versions of these packages you need for DepthAI, use pip: `pip3 install -r requirements.txt`
+DepthAI requires [numpy](https://numpy.org/) and [opencv-python](https://pypi.org/project/opencv-python/). To get the versions of these packages you need for DepthAI, use pip: `python3 -m pip install -r requirements.txt`
+
+Optional:
+For command line autocomplete when pressing TAB:
+On MAC OSX:
+`autoload -U bashcompinit`
+`bashcompinit`
+Add to .zshrc:
+`echo ~/.zshrc >> eval "$(register-python-argcomplete depthai.py)"`
+
+On other Linux based platforms:
+Add to .bashrc:
+`echo ~/.bashrc >> eval "$(register-python-argcomplete depthai.py)"`
+
+If you use any other interpreter: https://kislyuk.github.io/argcomplete/
 
 Files with `.so` extension are the python modules:  
 - `depthai.cpython-36m-x86_64-linux-gnu.so` built for Ubuntu 18.04 & Python 3.6  

--- a/README.md
+++ b/README.md
@@ -9,16 +9,9 @@ __Documentation is available at [https://docs.luxonis.com](https://docs.luxonis.
 DepthAI requires [numpy](https://numpy.org/) and [opencv-python](https://pypi.org/project/opencv-python/). To get the versions of these packages you need for DepthAI, use pip: `python3 -m pip install -r requirements.txt`
 
 Optional:
-For command line autocomplete when pressing TAB:
-On MAC OSX:
-`autoload -U bashcompinit`
-`bashcompinit`
-Add to .zshrc:
-`echo ~/.zshrc >> eval "$(register-python-argcomplete depthai.py)"`
-
-On other Linux based platforms:
+For command line autocomplete when pressing TAB, only bash interpreter supported now:
 Add to .bashrc:
-`echo ~/.bashrc >> eval "$(register-python-argcomplete depthai.py)"`
+`echo 'eval "$(register-python-argcomplete depthai.py)"' >> ~/.bashrc`
 
 If you use any other interpreter: https://kislyuk.github.io/argcomplete/
 

--- a/depthai_helpers/cli_utils.py
+++ b/depthai_helpers/cli_utils.py
@@ -1,8 +1,39 @@
 #!/usr/bin/env python3
 
 import argparse
-from enum import Enum
+try:
+    import argcomplete
+except ImportError:
+    raise ImportError('argcomplete module not found, run python3 -m pip install -r requirements.txt ')
+from argcomplete.completers import ChoicesCompleter
 
+from enum import Enum
+import os
+import consts.resource_paths
+
+def get_immediate_subdirectories(a_dir):
+    return [name for name in os.listdir(a_dir)
+            if os.path.isdir(os.path.join(a_dir, name))]
+
+stream_choices = ("metaout", "previewout", "jpegout", "left", "right", "depth_sipp", "disparity", "depth_color_h", "meta_d2h", "object_tracker")
+CNN_choices = get_immediate_subdirectories(consts.resource_paths.nn_resource_path)
+
+class RangeFloat(object):
+    def __init__(self, start, end):
+        self.start = start
+        self.end = end
+
+    def __eq__(self, other):
+        return self.start <= other <= self.end
+
+    def __contains__(self, item):
+        return self.__eq__(item)
+
+    def __iter__(self):
+        yield self
+
+    def __str__(self):
+        return '[{0},{1}]'.format(self.start, self.end)
 
 class PrintColors(Enum):
     HEADER = "\033[95m"
@@ -41,60 +72,88 @@ def parse_args():
                         type=str, required=False,
                         help="JSON-formatted pipeline config object. This will be override defaults used in this "
                              "script.")
+
     parser.add_argument("-brd", "--board", default=None, type=str,
                         help="BW1097, BW1098OBC - Board type from resources/boards/ (not case-sensitive). "
                              "Or path to a custom .json board config. Mutually exclusive with [-fv -rfv -b -r -w]")
-    parser.add_argument("-sh", "--shaves", default=None, type=int,
+
+    parser.add_argument("-sh", "--shaves", default=None, type=int, choices=range(1,15), metavar="[1-14]",
                         help="Number of shaves used by NN.")
-    parser.add_argument("-cmx", "--cmx_slices", default=None, type=int,
+
+    parser.add_argument("-cmx", "--cmx_slices", default=None, type=int, choices=range(1,15), metavar="[1-14]",
                         help="Number of cmx slices used by NN.")
-    parser.add_argument("-nce", "--NN_engines", default=None, type=int,
+
+    parser.add_argument("-nce", "--NN_engines", default=None, type=int, choices=range(0,3), metavar="[0-2]",
                         help="Number of NN_engines used by NN.")
-    parser.add_argument("-rgbr", "--rgb_resolution", default=1080, type=int,
-                        help="RGB cam res height: (1920x)1080, (3840x)2160 or (4056)x3040. Default: %(default)s")
+
+    parser.add_argument("-rgbr", "--rgb_resolution", default=1080, type=int, choices=['1080', '2160', '3040'],
+                        help="RGB cam res height: (1920x)1080, (3840x)2160 or (4056x)3040. Default: %(default)s")
+
     parser.add_argument("-rgbf", "--rgb_fps", default=30.0, type=float,
                         help="RGB cam fps: max 118.0 for H:1080, max 42.0 for H:2160. Default: %(default)s")
-    parser.add_argument("-monor", "--mono_resolution", default=720, type=int,
+
+    parser.add_argument("-monor", "--mono_resolution", default=720, type=int,  choices=['400', '720', '800'],
                         help="Mono cam res height: (1280x)720, (1280x)800 or (640x)400 - binning. Default: %(default)s")
+
     parser.add_argument("-monof", "--mono_fps", default=30.0, type=float,
                         help="Mono cam fps: max 60.0 for H:720 or H:800, max 120.0 for H:400. Default: %(default)s")
-    parser.add_argument("-dct", "--disparity_confidence_threshold", default=200, type=disparity_ct_type,
+
+    parser.add_argument("-dct", "--disparity_confidence_threshold", default=200, type=int, 
+                        choices=range(0,256), metavar="[0-255]",
                         help="Disparity_confidence_threshold.")
+
     parser.add_argument("-fv", "--field-of-view", default=None, type=float,
                         help="Horizontal field of view (HFOV) for the stereo cameras in [deg]. Default: 71.86deg.")
+
     parser.add_argument("-rfv", "--rgb-field-of-view", default=None, type=float,
                         help="Horizontal field of view (HFOV) for the RGB camera in [deg]. Default: 68.7938deg.")
+
     parser.add_argument("-b", "--baseline", default=None, type=float,
                         help="Left/Right camera baseline in [cm]. Default: 9.0cm.")
+
     parser.add_argument("-r", "--rgb-baseline", default=None, type=float,
                         help="Distance the RGB camera is from the Left camera. Default: 2.0cm.")
+
     parser.add_argument("-w", "--no-swap-lr", dest="swap_lr", default=None, action="store_false",
                         help="Do not swap the Left and Right cameras.")
+    
     parser.add_argument("-e", "--store-eeprom", default=False, action="store_true",
                         help="Store the calibration and board_config (fov, baselines, swap-lr) in the EEPROM onboard")
+    
     parser.add_argument("--clear-eeprom", default=False, action="store_true",
                         help="Invalidate the calib and board_config from EEPROM")
+    
     parser.add_argument("-o", "--override-eeprom", default=False, action="store_true",
                         help="Use the calib and board_config from host, ignoring the EEPROM data if programmed")
+    
     parser.add_argument("-dev", "--device-id", default="", type=str,
                         help="USB port number for the device to connect to. Use the word 'list' to show all devices "
                              "and exit.")
+    
     parser.add_argument("-debug", "--dev_debug", default=None, action="store_true",
                         help="Used by board developers for debugging.")
+    
     parser.add_argument("-fusb2", "--force_usb2", default=None, action="store_true",
                         help="Force usb2 connection")
-    parser.add_argument("-cnn", "--cnn_model", default="mobilenet-ssd", type=str,
+    
+    parser.add_argument("-cnn", "--cnn_model", default="mobilenet-ssd", type=str, choices=CNN_choices,
                         help="Cnn model to run on DepthAI")
-    parser.add_argument("-cnn2", "--cnn_model2", default="", type=str,
+    
+    parser.add_argument("-cnn2", "--cnn_model2", default="", type=str, choices=CNN_choices,
                         help="Cnn model to run on DepthAI for second-stage inference")
+    
     parser.add_argument('-cam', "--cnn_camera", default='rgb', choices=['rgb', 'left', 'right', 'left_right'],
                         help='Choose camera input for CNN (default: %(default)s)')
+    
     parser.add_argument("-dd", "--disable_depth", default=False, action="store_true",
                         help="Disable depth calculation on CNN models with bounding box output")
+    
     parser.add_argument("-bb", "--draw-bb-depth", default=False, action="store_true",
                         help="Draw the bounding boxes over the left/right/depth* streams")
+    
     parser.add_argument("-ff", "--full-fov-nn", default=False, action="store_true",
                         help="Full RGB FOV for NN, not keeping the aspect ratio")
+    
     parser.add_argument("-s", "--streams",
                         nargs="+",
                         type=stream_type,
@@ -103,9 +162,13 @@ def parse_args():
                         help=("Define which streams to enable \n"
                               "Format: stream_name or stream_name,max_fps \n"
                               "Example: -s metaout previewout \n"
-                              "Example: -s metaout previewout,10 depth_sipp,10"))
+                              "Example: -s metaout previewout,10 depth_sipp,10"))\
+                        .completer=ChoicesCompleter(stream_choices)
+    
     parser.add_argument("-v", "--video", default=None, type=str, required=False,
                         help="Path where to save video stream (existing file will be overwritten)")
+    
+    argcomplete.autocomplete(parser)
 
     options = parser.parse_args()
     any_options_set = any([options.field_of_view, options.rgb_field_of_view, options.baseline, options.rgb_baseline,
@@ -133,7 +196,6 @@ def stream_type(option):
         cli_print(msg_string, PrintColors.WARNING)
         raise ValueError(msg_string)
 
-    stream_choices = ["metaout", "previewout", "jpegout", "left", "right", "depth_sipp", "disparity", "depth_color_h", "meta_d2h", "object_tracker"]
     stream_name = option_list[0]
     if stream_name not in stream_choices:
         msg_string = "{0} is not in available stream list: \n{1}".format(stream_name, stream_choices)
@@ -151,15 +213,3 @@ def stream_type(option):
 
         stream_dict = {"name": stream_name, "max_fps": max_fps}
     return stream_dict
-
-def disparity_ct_type(value):
-    try: 
-        value = int(value)
-    except ValueError:
-        raise ValueError("Confidence threshold should be INT")
-    if value < 0 or value > 255:
-        msg_string = "{0} disparity confidence threshold is not in interval [0,255]. See --help".format(value)
-        cli_print(msg_string, PrintColors.WARNING)
-        raise ValueError(msg_string)
-    
-    return value

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy==1.18.3
 opencv-python==4.2.0.34
 requests
+argcomplete==1.12.0


### PR DESCRIPTION
Add support for argument autocomplete on TAB pressing, like any other app.
`python3 -m pip install -r requirements.txt`
`echo 'eval "$(register-python-argcomplete depthai.py)"' >> ~/.bashrc`

Only bash is supported for now.
On macos run depthai from bash: from terminal: `bash` then follow instructions.

When pressing tab it will list all available arguments, and all available options for that argument, for example:
`./depthai.py -cnn` TAB will list all supported CNN models.
`./depthai.py -cnn mobi` TAB will autocomplete to mobilenet-ssd