### PR TITLE
Fix requirements on RPi 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy==1.18.3
 opencv-python==4.2.0.34; platform_machine != "armv7l"
-opencv-python==4.1.1.26; platform_machine == "armv7l"
+opencv-python==4.1.0.25; platform_machine == "armv7l"
 requests==2.24.0
 argcomplete==1.12.0


### PR DESCRIPTION
This PR resolves #168 

As specified [here](https://github.com/piwheels/packages/issues/59) the opencv-python version we're using requires a workaround due to an error

```
undefined symbol: __atomic_fetch_add_8
```

And the proposed workaround consists of adding an environment variable

```
LD_PRELOAD=/usr/lib/arm-linux-gnueabihf/libatomic.so.1
```

However, if we downgrade the `opencv-python` version on RPi from `4.1.1.26` to `4.1.0.25`, the error does not occur and no workaround is needed