### PR TITLE
Two stage NN + calibration fix

### DIFF
--- a/depthai_helpers/config_manager.py
+++ b/depthai_helpers/config_manager.py
@@ -291,9 +291,9 @@ class BlobManager:
         # compile modules
         self.default_blob=True
         if compile_model:
-            self.blob_file, self.default_blob = self.compileBlob(self.blob_file)
+            self.blob_file, self.default_blob = self.compileBlob(self.args['cnn_model'])
             if self.args['cnn_model2']:
-                self.blob_file2, self.default_blob = self.compileBlob(self.blob_file2)
+                self.blob_file2, self.default_blob = self.compileBlob(self.args['cnn_model2'], False)
 
     def getLabels(self):
         # try and load labels
@@ -331,7 +331,9 @@ class BlobManager:
 
         return blobFile, blobFileConfig
 
-    def compileBlob(self, blob_file):
+    def compileBlob(self, nn_model, isFirstNN=True):
+        blob_file, _ = self.getBlobFiles(nn_model, isFirstNN)
+
         default_blob=False
         shave_nr = 7 if self.args['shaves'] is None else self.args['shaves']
         cmx_slices = 7 if self.args['cmx_slices'] is None else self.args['cmx_slices']
@@ -350,7 +352,7 @@ class BlobManager:
         outblob_file = blob_file + ".sh" + str(shave_nr) + "cmx" + str(cmx_slices) + "NCE" + str(NCE_nr)
         if(not Path(outblob_file).exists()):
             cli_print("Compiling model for {0} shaves, {1} cmx_slices and {2} NN_engines ".format(str(shave_nr), str(cmx_slices), str(NCE_nr)), PrintColors.RED)
-            ret = download_model(self.args['cnn_model'], shave_nr_opt, cmx_slices_opt, NCE_nr, outblob_file)
+            ret = download_model(nn_model, shave_nr_opt, cmx_slices_opt, NCE_nr, outblob_file)
             if(ret != 0):
                 cli_print("Model compile failed. Falling back to default.", PrintColors.WARNING)
                 default_blob=True

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ open3d==0.10.0.0; platform_machine != "armv7l"
 # depthai==0.2.0.1
 
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/
-depthai==0.2.0.1+690d622f7accefae63b19ea9f47fd2d1b51eb44f
+depthai==0.2.0.1+8cf9e4125e54701cd71a50d04cb2d6f30907ab0e

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ open3d==0.10.0.0
 # depthai==0.2.0.1
 
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/
-depthai==0.2.0.1+34fb671932770318479f0980075d51cbd27137c9
+depthai==0.2.0.1+690d622f7accefae63b19ea9f47fd2d1b51eb44f


### PR DESCRIPTION
Two stage NN was broken due to a small error in refactorization done for arg/config manager.

```
./depthai_demo.py -cnn face-detection-retail-0004 -cnn2 landmarks-regression-retail-0009 -cam left_right -sh 12 -cmx 12 -nce 2 
```
was broken.

The problem appeared only when the model was auto-compiled.

Calibration was also fixed when EEPROM was empty.