### PR TITLE
Option to run NN on stereo rectified streams

### DIFF
--- a/depthai_helpers/arg_manager.py
+++ b/depthai_helpers/arg_manager.py
@@ -148,7 +148,8 @@ class CliArgs:
         parser.add_argument("-cnn2", "--cnn_model2", default="", type=str, choices=_CNN_choices,
                             help="Cnn model to run on DepthAI for second-stage inference")
         
-        parser.add_argument('-cam', "--cnn_camera", default='rgb', choices=['rgb', 'left', 'right', 'left_right'],
+        parser.add_argument('-cam', "--cnn_camera", default='rgb',
+                            choices=['rgb', 'left', 'right', 'left_right', 'rectified_left', 'rectified_right', 'rectified_left_right'],
                             help='Choose camera input for CNN (default: %(default)s)')
         
         parser.add_argument("-dd", "--disable_depth", default=False, action="store_true",

--- a/depthai_helpers/config_manager.py
+++ b/depthai_helpers/config_manager.py
@@ -129,7 +129,7 @@ class DepthConfigManager:
         self.linuxCheckApplyUsbRules()
 
         # left_right double NN check.
-        if self.args['cnn_camera'] == 'left_right':
+        if self.args['cnn_camera'] in ['left_right', 'rectified_left_right']:
             if self.args['NN_engines'] is None:
                 self.args['NN_engines'] = 2
                 self.args['shaves'] = 6 if self.args['shaves'] is None else self.args['shaves'] - self.args['shaves'] % 2

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ open3d==0.10.0.0; platform_machine != "armv7l"
 # depthai==0.2.0.1
 
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/
-depthai==0.2.0.1+78f0f40db764c4981da9e74de387b61c785e4d32
+depthai==0.2.0.1+406f48b91e9bd01824c748a0028e07595b5557dd


### PR DESCRIPTION
Source code PR: https://github.com/luxonis/depthai-python/pull/53

New options for `-cam / --cnn_camera`: `rectified_left`, `rectified_right`, `rectified_left_right` (both L and R rectified).
Note: by default the rectified streams are mirrored, so depending on usecase this option may be needed: `-mirror_rectified false`
