### PR TITLE
Fix -vv / --verbose option for NN

### DIFF
--- a/depthai_demo.py
+++ b/depthai_demo.py
@@ -137,10 +137,10 @@ class DepthAI:
             meta = packet.getMetadata()
             print("[{:.6f} {:15s}]".format(time()-time_start, stream_name), end='')
             if meta is not None:
-                print(" {:.6f}".format(meta.getTimestamp()), meta.getSequenceNum(), end='')
-                if not (stream_name.startswith('disparity')
-                     or stream_name.startswith('depth')):
-                    print('', meta.getCameraName(), end='')
+                source = meta.getCameraName()
+                if stream_name.startswith('disparity') or stream_name.startswith('depth'):
+                    source += ' (rectified)'
+                print(" {:.6f}".format(meta.getTimestamp()), meta.getSequenceNum(), source, end='')
             print()
             return
 

--- a/depthai_demo.py
+++ b/depthai_demo.py
@@ -133,13 +133,13 @@ class DepthAI:
         self.reset_process_wd()
 
         time_start = time()
-        def print_packet_info(packet):
+        def print_packet_info(packet, stream_name):
             meta = packet.getMetadata()
-            print("[{:.6f} {:15s}]".format(time()-time_start, packet.stream_name), end='')
+            print("[{:.6f} {:15s}]".format(time()-time_start, stream_name), end='')
             if meta is not None:
                 print(" {:.6f}".format(meta.getTimestamp()), meta.getSequenceNum(), end='')
-                if not (packet.stream_name.startswith('disparity')
-                     or packet.stream_name.startswith('depth')):
+                if not (stream_name.startswith('disparity')
+                     or stream_name.startswith('depth')):
                     print('', meta.getCameraName(), end='')
             print()
             return
@@ -206,7 +206,7 @@ class DepthAI:
                     os._exit(10)
 
             for _, nnet_packet in enumerate(self.nnet_packets):
-                if args['verbose']: print_packet_info(nnet_packet)
+                if args['verbose']: print_packet_info(nnet_packet, 'NNet')
 
                 meta = nnet_packet.getMetadata()
                 camera = 'rgb'
@@ -221,7 +221,7 @@ class DepthAI:
                 window_name = packet.stream_name
                 if packet.stream_name not in stream_names:
                     continue # skip streams that were automatically added
-                if args['verbose']: print_packet_info(packet)
+                if args['verbose']: print_packet_info(packet, packet.stream_name)
                 packetData = packet.getData()
                 if packetData is None:
                     print('Invalid packet data!')


### PR DESCRIPTION
Fix `-vv` / `--verbose` crash when `metaout` stream is enabled. Also display camera source for `disparity`/`depth`.
Should fix issue https://github.com/luxonis/depthai/issues/228

Example output for `./depthai_demo.py -vv -s previewout left right depth rectified_left metaout -sync -rgbf 20 -monof 20`:
```
[16.250735 NNet           ] 120.989991 314 rgb
[16.251078 previewout     ] 120.989991 314 rgb
[16.252138 left           ] 121.039615 274 left
[16.253608 right          ] 121.039640 274 right
[16.255058 depth          ] 121.039615 274 right (rectified)
[16.263112 rectified_left ] 121.039615 274 left
[16.299313 NNet           ] 121.039984 315 rgb
[16.299623 previewout     ] 121.039984 315 rgb
[16.300541 left           ] 121.089588 275 left
[16.301891 right          ] 121.089611 275 right
[16.302917 depth          ] 121.089588 275 right (rectified)
[16.310609 rectified_left ] 121.089588 275 left

```