### PR TITLE
Gen1 updates

### DIFF
--- a/depthai_demo.py
+++ b/depthai_demo.py
@@ -137,14 +137,17 @@ class DepthAI:
         self.reset_process_wd()
 
         time_start = time()
+        def print_packet_info_header():
+            print('[hostTimestamp streamName] devTstamp seq camSrc width height Bpp')
         def print_packet_info(packet, stream_name):
             meta = packet.getMetadata()
             print("[{:.6f} {:15s}]".format(time()-time_start, stream_name), end='')
             if meta is not None:
                 source = meta.getCameraName()
                 if stream_name.startswith('disparity') or stream_name.startswith('depth'):
-                    source += ' (rectified)'
+                    source += '(rectif)'
                 print(" {:.6f}".format(meta.getTimestamp()), meta.getSequenceNum(), source, end='')
+                print('', meta.getFrameWidth(), meta.getFrameHeight(), meta.getFrameBytesPP(), end='')
             print()
             return
 
@@ -188,6 +191,7 @@ class DepthAI:
 
         ops = 0
         prevTime = time()
+        if args['verbose']: print_packet_info_header()
         while self.runThread:
             # retreive data from the device
             # data is stored in packets, there are nnet (Neural NETwork) packets which have additional functions for NNet result interpretation

--- a/depthai_helpers/arg_manager.py
+++ b/depthai_helpers/arg_manager.py
@@ -165,6 +165,9 @@ class CliArgs:
         parser.add_argument("-sync", "--sync-video-meta", default=False, action="store_true",
                             help="Synchronize 'previewout' and 'metaout' streams")
 
+        parser.add_argument("-seq", "--sync-sequence-numbers", default=False, action="store_true",
+                            help="Synchronize sequence numbers for all packets. Experimental")
+
         parser.add_argument("-vv", "--verbose", default=False, action="store_true",
                         help="Verbose, print info about received packets.")
         parser.add_argument("-s", "--streams",

--- a/depthai_helpers/arg_manager.py
+++ b/depthai_helpers/arg_manager.py
@@ -168,6 +168,10 @@ class CliArgs:
         parser.add_argument("-seq", "--sync-sequence-numbers", default=False, action="store_true",
                             help="Synchronize sequence numbers for all packets. Experimental")
 
+        parser.add_argument("-u", "--usb-chunk-KiB", default=64, type=int,
+                            help="USB transfer chunk on device. Higher (up to megabytes) "
+                            "may improve throughput, or 0 to disable chunking. Default: %(default)s")
+
         parser.add_argument("-vv", "--verbose", default=False, action="store_true",
                         help="Verbose, print info about received packets.")
         parser.add_argument("-s", "--streams",

--- a/depthai_helpers/config_manager.py
+++ b/depthai_helpers/config_manager.py
@@ -256,6 +256,7 @@ class DepthConfigManager:
             {
                 'sync_video_meta_streams': self.args['sync_video_meta'],
                 'sync_sequence_numbers'  : self.args['sync_sequence_numbers'],
+                'usb_chunk_KiB' : self.args['usb_chunk_KiB'],
             },
             #'video_config':
             #{

--- a/depthai_helpers/config_manager.py
+++ b/depthai_helpers/config_manager.py
@@ -255,6 +255,7 @@ class DepthConfigManager:
             'app':
             {
                 'sync_video_meta_streams': self.args['sync_video_meta'],
+                'sync_sequence_numbers'  : self.args['sync_sequence_numbers'],
             },
             #'video_config':
             #{

--- a/depthai_helpers/version_check.py
+++ b/depthai_helpers/version_check.py
@@ -22,7 +22,9 @@ def check_depthai_version():
     version_required = get_version_from_requirements()
     if version_required is not None:
         print('Depthai version required:  ', version_required)
-        if version_required != depthai.__version__:
+        if depthai.__version__.endswith('+dev'):
+            print('Depthai development version found, skipping check.')
+        elif version_required != depthai.__version__:
             raise ValueError(f"\033[1;5;31mVersion mismatch \033[0m\033[91m between installed depthai lib and the required one by the script.\033[0m \n\
                 Required:  {version_required}\n\
                 Installed: {depthai.__version__}\n\

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ open3d==0.10.0.0; platform_machine != "armv7l"
 # depthai==0.2.0.1
 
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/
-depthai==0.2.0.1+fe3741e60c7e167a888f67b2a3263623ced170b4
+depthai==0.2.0.1+566287cbfb5cbbde6aaea209a7ec7ae302bd41e3

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ open3d==0.10.0.0; platform_machine != "armv7l"
 # depthai==0.2.0.1
 
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/
-depthai==0.2.0.1+f91a36fac86a0f4383e863e04cb651869a1603ac
+depthai==0.2.0.1+fe3741e60c7e167a888f67b2a3263623ced170b4


### PR DESCRIPTION
- Skip DepthAI library version check for local/development builds.
- Add an option:
```
  -seq, --sync-sequence-numbers
                        Synchronize sequence numbers for all packets.
                        Experimental
```
- With `-vv`/`--verbose` print more metadata fields, and also print a header. Example for:
`./depthai_demo.py -s metaout previewout jpegout left right depth object_tracker rectified_left rectified_right color -vv -seq`
```
[hostTimestamp streamName] devTstamp seq camSrc width height Bpp
[0.736409 object_tracker ] 3.836959 1 rgb 648 1 1
[0.752393 previewout     ] 3.836959 1 rgb 300 300 3
[0.756711 color          ] 3.836959 1 rgb 1920 1080 1
[0.772088 NNet           ] 3.836959 1 rgb 3604 1 1
[0.772309 previewout     ] 3.870289 2 rgb 300 300 3
[0.772653 object_tracker ] 3.870289 2 rgb 648 1 1
[0.772730 color          ] 3.870289 2 rgb 1920 1080 1
[0.799922 previewout     ] 3.903617 3 rgb 300 300 3
[0.800301 object_tracker ] 3.903617 3 rgb 648 1 1
[0.803786 NNet           ] 3.870289 2 rgb 3604 1 1
[0.803880 color          ] 3.903617 3 rgb 1920 1080 1
[0.832494 color          ] 3.936946 4 rgb 1920 1080 1
[0.869391 NNet           ] 3.903617 3 rgb 3604 1 1
[0.869559 previewout     ] 3.936946 4 rgb 300 300 3
[0.869995 object_tracker ] 3.936946 4 rgb 648 1 1
....
[2.760325 color          ] 5.836678 61 rgb 1920 1080 1
[2.763133 previewout     ] 5.836678 61 rgb 300 300 3
[2.763657 object_tracker ] 5.836678 61 rgb 648 1 1
[2.776636 color          ] 5.870007 62 rgb 1920 1080 1
[2.795374 NNet           ] 5.703364 57 rgb 3604 1 1
[2.795546 previewout     ] 5.870007 62 rgb 300 300 3
[2.796009 object_tracker ] 5.870007 62 rgb 648 1 1
[2.796080 left           ] 5.893464 62 left 1280 720 1          << Mono cameras started here
[2.818499 right          ] 5.893487 62 right 1280 720 1
[2.822901 color          ] 5.903335 63 rgb 1920 1080 1
[2.830298 previewout     ] 5.903335 63 rgb 300 300 3
[2.851704 object_tracker ] 5.903335 63 rgb 648 1 1
[2.851894 depth          ] 5.893464 62 right(rectif) 1280 720 2
[2.858472 rectified_left ] 5.893464 62 left 1280 720 1
[2.872956 rectified_right] 5.893464 62 right 1280 720 1
[2.922545 left           ] 5.926778 63 left 1280 720 1
[2.951264 right          ] 5.926792 63 right 1280 720 1
[2.951975 color          ] 5.936662 64 rgb 1920 1080 1
[2.960922 previewout     ] 5.936662 64 rgb 300 300 3
[2.961507 object_tracker ] 5.936662 64 rgb 648 1 1
[2.961582 depth          ] 5.926778 63 right(rectif) 1280 720 2
[2.966263 rectified_left ] 5.926778 63 left 1280 720 1
[2.966814 rectified_right] 5.926778 63 right 1280 720 1
[2.967308 left           ] 5.960093 64 left 1280 720 1
[2.967773 right          ] 5.960116 64 right 1280 720 1
[2.968166 color          ] 5.969991 65 rgb 1920 1080 1
[2.971474 previewout     ] 5.969991 65 rgb 300 300 3
[2.972091 object_tracker ] 5.969991 65 rgb 648 1 1
[2.972172 depth          ] 5.960093 64 right(rectif) 1280 720 2
[2.977905 rectified_left ] 5.960093 64 left 1280 720 1
[3.028288 NNet           ] 5.903335 63 rgb 3604 1 1
[3.028406 rectified_right] 5.960093 64 right 1280 720 1
[3.028939 left           ] 5.993408 65 left 1280 720 1
[3.029436 right          ] 5.993422 65 right 1280 720 1
[3.029864 color          ] 6.003321 66 rgb 1920 1080 1
[3.032725 object_tracker ] 6.003321 66 rgb 648 1 1
[3.032836 previewout     ] 6.003321 66 rgb 300 300 3
[3.033329 left           ] 6.026723 66 left 1280 720 1
[3.033843 right          ] 6.026743 66 right 1280 720 1
```


Source code PR: https://github.com/luxonis/depthai-python/pull/58