### PR TITLE
Custom firmware option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ MANIFEST
 *.idea
 # DepthAI-Specific
 dataset/
+fw_cache/
 depthai.calib
 mesh_left.calib
 mesh_right.calib

--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@ MANIFEST
 *.idea
 # DepthAI-Specific
 dataset/
-fw_cache/
+.fw_cache/
 depthai.calib
 mesh_left.calib
 mesh_right.calib

--- a/depthai_helpers/arg_manager.py
+++ b/depthai_helpers/arg_manager.py
@@ -176,6 +176,9 @@ class CliArgs:
                             help="USB transfer chunk on device. Higher (up to megabytes) "
                             "may improve throughput, or 0 to disable chunking. Default: %(default)s")
 
+        parser.add_argument("-fw", "--firmware", default="", type=str,
+                            help="Commit hash for custom FW, downloaded from Artifactory")
+
         parser.add_argument("-vv", "--verbose", default=False, action="store_true",
                         help="Verbose, print info about received packets.")
         parser.add_argument("-s", "--streams",

--- a/depthai_helpers/arg_manager.py
+++ b/depthai_helpers/arg_manager.py
@@ -176,7 +176,7 @@ class CliArgs:
                             help="USB transfer chunk on device. Higher (up to megabytes) "
                             "may improve throughput, or 0 to disable chunking. Default: %(default)s")
 
-        parser.add_argument("-fw", "--firmware", default="", type=str,
+        parser.add_argument("-fw", "--firmware", default=None, type=str,
                             help="Commit hash for custom FW, downloaded from Artifactory")
 
         parser.add_argument("-vv", "--verbose", default=False, action="store_true",

--- a/depthai_helpers/config_manager.py
+++ b/depthai_helpers/config_manager.py
@@ -42,7 +42,7 @@ class DepthConfigManager:
             return 1.0
 
     def getCustomFirmwarePath(self, commit):
-        fwdir = 'fw_cache/'
+        fwdir = '.fw_cache/'
         if not os.path.exists(fwdir):
             os.mkdir(fwdir)
         fw_variant = ''

--- a/depthai_helpers/config_manager.py
+++ b/depthai_helpers/config_manager.py
@@ -68,7 +68,7 @@ class DepthConfigManager:
     def getCommandFile(self):
         debug_mode = False
         cmd_file = ''
-        if self.args['firmware'] != '':
+        if self.args['firmware'] != None:
             self.custom_fw_commit = self.args['firmware']
         if self.args['dev_debug'] == None:
             # Debug -debug flag NOT present, check first for custom firmware


### PR DESCRIPTION
This is mostly intended for quick experiments that modify only the device firmware, and it helps to skip the rebuild of the python wheel.

The `FIRMWARE` commit hash value will be provided by Luxonis (to ensure it is compatible with the host app), and can be hardcoded in https://github.com/luxonis/depthai/blob/85db9ff/depthai_helpers/config_manager.py#L17 (on a given branch)
or inputted by this command line option:
```
  -fw FIRMWARE, --firmware FIRMWARE
                        Commit hash for custom FW, downloaded from Artifactory
```

The firmware specified is downloaded from [Luxonis Artifactory - device side](https://artifacts.luxonis.com/artifactory/luxonis-myriad-snapshot-local/depthai-device-side/) and cached locally inside the repo, in `.fw_cache` directory. Both normal (USB3-enabled) and USB2 variants of the firmware are supported.