### PR TITLE
fixed missing blob error in calibrate.py

### DIFF
--- a/calibrate.py
+++ b/calibrate.py
@@ -15,7 +15,7 @@ from pathlib import Path
 import shutil
 import consts.resource_paths
 import json
-
+from depthai_helpers.config_manager import BlobManager
 from depthai_helpers.version_check import check_depthai_version
 check_depthai_version()
 
@@ -129,6 +129,16 @@ class Main:
 
     def __init__(self):
         self.args = vars(parse_args())
+        blob_man_args = {
+                        'cnn_model':'mobilenet-ssd',
+                        'cnn_model2':'',
+                        'model_compilation_target':'auto'
+                    }
+        shaves = 7
+        cmx_slices = 7
+        NN_engines = 1
+        blobMan = BlobManager(blob_man_args, True , shaves, cmx_slices,NN_engines)
+
         self.config = {
             'streams':
                 ['left', 'right'] if not on_embedded else
@@ -140,11 +150,11 @@ class Main:
                 },
             'ai':
                 {
-                    'blob_file': consts.resource_paths.blob_fpath,
-                    'blob_file_config': consts.resource_paths.blob_config_fpath,
-                    'shaves' : 7,
-                    'cmx_slices' : 7,
-                    'NN_engines' : 1,
+                    'blob_file': blobMan.blob_file,
+                    'blob_file_config': blobMan.blob_file_config,
+                    'shaves' : shaves,
+                    'cmx_slices' : cmx_slices,
+                    'NN_engines' : NN_engines,
                 },
             'board_config':
                 {


### PR DESCRIPTION
With model zoo being fetched using downloader `calibrate.py` was not working since blob was not found. added a small fix to download `mobilenet-ssd` if not found during the calibration routine. 