### PR TITLE
Fix crash on 2nd device object delete

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,7 @@ requests==2.24.0
 argcomplete==1.12.0
 open3d==0.10.0.0; platform_machine != "armv7l"
 pyyaml==5.3.1
-depthai==0.3.0.0
+# depthai==0.3.0.0
+
+--extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/
+depthai==0.3.0.0+765e5e8de2a0d462397f6a00f747e85c301dae74


### PR DESCRIPTION
Source code PR: https://github.com/luxonis/depthai-python/pull/64

Should fix issue https://github.com/luxonis/depthai/issues/259

Tested by replacing this line: https://github.com/luxonis/depthai/blob/ddfe91b7/depthai_demo.py#L382
```diff
 if __name__ == "__main__":
     dai = DepthAI()
-    dai.startLoop()
+    while True: dai.startLoop()

```
and pressing `q` during streaming, to have the loop restart.

Also tested that the watchdog still works fine, by manually resetting the device while streaming.