### PR TITLE
subprocess.run command doesn't have capture_output arg till python3.7 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ log_system_information.json
 *.mvcmd
 *.so
 *.prof
+*csv

--- a/model_compiler/model_compiler.py
+++ b/model_compiler/model_compiler.py
@@ -24,8 +24,12 @@ def download_model(model, model_zoo_folder):
     model_downloader_options = model_downloader_options.split()
     downloader_cmd = [sys.executable, f"{model_downloader_path}"]
     downloader_cmd = np.concatenate((downloader_cmd, model_downloader_options))
+    version = int(sys.version.split()[0].split('.')[1])
     # print(downloader_cmd)
-    result = subprocess.run(downloader_cmd, capture_output=True)
+    if version < 7:
+        result = subprocess.run(downloader_cmd, check=True)
+    else :
+        result = subprocess.run(downloader_cmd, capture_output=True)
     if result.returncode != 0:
         raise RuntimeError(f"Model downloader failed! Error: {result.stderr}")
     


### PR DESCRIPTION
checking python version to determine whether to use  `capture_output` as arg to subprocess.run or not in model_compiler.py