### PR TITLE
RGB camera fixes + key controls for manual focus/exposure

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ pyyaml==5.3.1
 # depthai==0.3.0.0
 
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/
-depthai==0.3.0.0+fac49836bb238e56eee5f2ad1a407ee8421e3476
+depthai==0.3.0.0+cd9672d8a8eb48811889241a131a655caa2aeee7


### PR DESCRIPTION
Source code PR: https://github.com/luxonis/depthai-python/pull/68

Device FW updates:
- fix potential crash with RGB 12MP (`-rgbr 3040`) + depth
- fix the cropping area for 4K (`-rgbr 2160`) - make it centered, it was top-left

Add some key controls for RGB manual exposure/focus:
```
    Control:      key[dec/inc]  min..max
    exposure time:     i   o    1..33333 [us]
    sensitivity iso:   k   l    100..1600
    focus:             ,   .    0..255 [far..near]

```