### PR TITLE
Use --user flag for system-wide installation

### DIFF
--- a/install_requirements.py
+++ b/install_requirements.py
@@ -3,7 +3,14 @@
 import subprocess
 import sys
 
-subprocess.check_call([sys.executable, "-m", "pip", "install", "pip", "-U"])
+# https://stackoverflow.com/a/58026969/5494277
+in_venv = getattr(sys, "real_prefix", getattr(sys, "base_prefix", sys.prefix)) != sys.prefix
+pip_call = [sys.executable, "-m", "pip"]
+
+if not in_venv:
+    pip_call.append("--user")
+
+subprocess.check_call([*pip_call, "install", "pip", "-U"])
 # temporary workaroud for issue between main and develop
-subprocess.check_call([sys.executable, "-m", "pip", "uninstall", "depthai", "--yes"])
-subprocess.check_call([sys.executable, "-m", "pip", "install", "-r", "requirements.txt"])
+subprocess.check_call([*pip_call, "uninstall", "depthai", "--yes"])
+subprocess.check_call([*pip_call, "install", "-r", "requirements.txt"])

--- a/install_requirements.py
+++ b/install_requirements.py
@@ -7,13 +7,11 @@ import sys
 in_venv = getattr(sys, "real_prefix", getattr(sys, "base_prefix", sys.prefix)) != sys.prefix
 pip_call = [sys.executable, "-m", "pip"]
 pip_install = pip_call + ["install"]
-pip_uninstall = pip_call + ["uninstall"]
 
 if not in_venv:
     pip_install.append("--user")
-    pip_uninstall.append("--user")
 
 subprocess.check_call([*pip_install, "pip", "-U"])
 # temporary workaroud for issue between main and develop
-subprocess.check_call([*pip_uninstall, "depthai", "--yes"])
+subprocess.check_call([*pip_call, "uninstall", "depthai", "--yes"])
 subprocess.check_call([*pip_install, "-r", "requirements.txt"])

--- a/install_requirements.py
+++ b/install_requirements.py
@@ -6,11 +6,14 @@ import sys
 # https://stackoverflow.com/a/58026969/5494277
 in_venv = getattr(sys, "real_prefix", getattr(sys, "base_prefix", sys.prefix)) != sys.prefix
 pip_call = [sys.executable, "-m", "pip"]
+pip_install = pip_call + ["install"]
+pip_uninstall = pip_call + ["uninstall"]
 
 if not in_venv:
-    pip_call.append("--user")
+    pip_install.append("--user")
+    pip_uninstall.append("--user")
 
-subprocess.check_call([*pip_call, "install", "pip", "-U"])
+subprocess.check_call([*pip_install, "pip", "-U"])
 # temporary workaroud for issue between main and develop
-subprocess.check_call([*pip_call, "uninstall", "depthai", "--yes"])
-subprocess.check_call([*pip_call, "install", "-r", "requirements.txt"])
+subprocess.check_call([*pip_uninstall, "depthai", "--yes"])
+subprocess.check_call([*pip_install, "-r", "requirements.txt"])


### PR DESCRIPTION
This PR adds the `--user` flag to install commands if the installation is system-wide (not from virtualenv)

Since the virtualenv itself does not allow the `--user` flag, failing with error

```
ERROR: Can not perform a '--user' install. User site-packages are not visible in this virtualenv.
```
an additional check is added to determine if the interpreter used by the user is from virtualenv or not

Tested on Linux (both system-wide and virtualenv) and Mac (both system-wide and virtualenv)