### PR TITLE
Increase RGB/Mono manual exposure max limit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ requests==2.24.0
 argcomplete==1.12.1
 open3d==0.10.0.0; platform_machine != "armv7l" and python_version < "3.9"
 pyyaml==5.3.1
-depthai==0.4.0.0
+#depthai==0.4.0.0
 
-#--extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/
-#depthai==0.3.0.0+cd9672d8a8eb48811889241a131a655caa2aeee7
+--extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/
+depthai==0.4.0.0+4f19e0e96fe468ca11faee8cf0d3f3dc38e86578


### PR DESCRIPTION
It was previously limited to about 33ms from device side.
To set larger exposures, the FPS need to be reduced accordingly (depthai_demo.py options `-rgbf` / `-monof`), for example 5 fps for max 200ms exposure.

Use `S` key to toggle between the cameras (`rgb` or `mono`) where the exposure control is applied. And change with:
```
            # Control:      key[dec/inc]  min..max
            # exposure time:     i   o    1..(1000*1000/fps) [us]
            # sensitivity iso:   k   l    100..1600
```
For mono cameras, a flicker artifact could appear in the frame following a change in the exposure/iso value. This needs to be debugged.

For mono cameras, currently the max exposure that can be applied:
- 0.596s at  640x400
- 1.252s at 1280x720 or 1280x800 - however with the fps set below 1.0 there's a risk the watchdog could kick in and do a reset. Workaround: add `meta_d2h` to the list of streams, for example: `-s left right meta_d2h -monof 0.5`. Also if the FPS is set to lower than the camera can output, it will be capped accordingly, for example `0.5` here results in an actual `0.79`
 