### PR TITLE
Gen1: flip camera view on OAK-1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ pyyaml==5.3.1
 #depthai==0.4.0.0
 
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/
-depthai==0.4.0.0+4f19e0e96fe468ca11faee8cf0d3f3dc38e86578
+depthai==0.4.0.0+a13b9939031c2aa794e8aa3e024d35734dc2c24c


### PR DESCRIPTION
Updated depthai lib/firmware to rotate the RGB camera view by 180° on OAK-1, and obtain a normal view with USB Type-C connector downwards.

Should fix issue https://github.com/luxonis/depthai/issues/200