### PR TITLE
Make Open3D installation optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ __Documentation is available at [https://docs.luxonis.com](https://docs.luxonis.
 DepthAI Demo requires [numpy](https://numpy.org/), [opencv-python](https://pypi.org/project/opencv-python/) and [depthai](https://github.com/luxonis/depthai-api). 
 To get the versions of these packages you need for the program, use pip: (Make sure pip is upgraded: ` python3 -m pip install -U pip`)
 ```
-python3 -m pip install -r requirements.txt 
+python3 install_requirements.py
 ```
 
 Optional:

--- a/depthai_helpers/projector_3d.py
+++ b/depthai_helpers/projector_3d.py
@@ -1,7 +1,15 @@
 #!/usr/bin/env python3
+import traceback
+import sys
 
-import numpy as np
-import open3d as o3d
+try:
+    import open3d as o3d
+except ImportError:
+    traceback.print_exc()
+    print("Importing open3d failed, please run the following command or visit https://pypi.org/project/open3d/")
+    print()
+    print(sys.executable  + " -m pip install open3d")
+
 
 class PointCloudVisualizer():
     def __init__(self, intrinsic_matrix, width, height):

--- a/install_requirements.py
+++ b/install_requirements.py
@@ -15,3 +15,7 @@ subprocess.check_call([*pip_install, "pip", "-U"])
 # temporary workaroud for issue between main and develop
 subprocess.check_call([*pip_call, "uninstall", "depthai", "--yes"])
 subprocess.check_call([*pip_install, "-r", "requirements.txt"])
+try:
+    subprocess.check_call([*pip_install, "-r", "requirements-optional.txt"])
+except subprocess.CalledProcessError as ex:
+    print(f"Optional dependencies were not installed (exit code {ex.returncode})")

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,0 +1,1 @@
+open3d==0.10.0.0; platform_machine != "armv7l" and python_version < "3.9"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ numpy==1.19.3
 opencv-python==4.4.0.46
 requests==2.24.0
 argcomplete==1.12.1
-open3d==0.10.0.0; platform_machine != "armv7l" and python_version < "3.9"
 pyyaml==5.3.1
 #depthai==0.4.0.0
 


### PR DESCRIPTION
Currently, most of the cases when `install_requirements.py` fails are due to open3d library being not available.

This PR makes this dependency optional, as it's only needed with `-pcl` flag enabled (also added a prompt there if open3d is missing)