### PR TITLE
Bump opencv version in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy==1.19.3
-opencv-python==4.4.0.46
+opencv-python==4.5.1.48
 requests==2.24.0
 argcomplete==1.12.1
 open3d==0.10.0.0; platform_machine != "armv7l" and python_version < "3.9"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.19.3
+numpy==1.19.5
 opencv-python==4.5.1.48
 requests==2.24.0
 argcomplete==1.12.1


### PR DESCRIPTION
Bump opencv version (and matching numpy version) to the latest.
When `4.4.0.46` was released Mac OS big sur was not out.
Tested on all platforms (RPI, Linux, Windows, MacOS)