### PR TITLE
Gen1 'depthai_demo' / 'calibrate' script updates

### DIFF
--- a/calibrate.py
+++ b/calibrate.py
@@ -78,12 +78,6 @@ def parse_args():
     parser.add_argument("-brd", "--board", default=None, type=str,
                         help="BW1097, BW1098OBC - Board type from resources/boards/ (not case-sensitive). "
                             "Or path to a custom .json board config. Mutually exclusive with [-fv -b -w]")
-    parser.add_argument("-fv", "--field-of-view", default=None, type=float,
-                        help="Horizontal field of view (HFOV) for the stereo cameras in [deg]. Default: 71.86deg.")
-    parser.add_argument("-b", "--baseline", default=None, type=float,
-                        help="Left/Right camera baseline in [cm]. Default: 9.0cm.")
-    parser.add_argument("-w", "--no-swap-lr", dest="swap_lr", default=None, action="store_false",
-                        help="Do not swap the Left and Right cameras.")
     parser.add_argument("-debug", "--dev_debug", default=None, action='store_true',
                         help="Used by board developers for debugging.")
     parser.add_argument("-fusb2", "--force_usb2", default=False, action="store_true",
@@ -95,15 +89,10 @@ def parse_args():
 
     options = parser.parse_args()
 
-    if (options.board is not None) and ((options.field_of_view is not None)
-                                     or (options.baseline      is not None)
-                                     or (options.swap_lr       is not None)):
-        parser.error("[-brd] is mutually exclusive with [-fv -b -w]")
-
-    # Set some defaults after the above check
-    if options.field_of_view is None: options.field_of_view = 71.86
-    if options.baseline      is None: options.baseline = 9.0
-    if options.swap_lr       is None: options.swap_lr = True
+    # Set some extra defaults, `-brd` would override them
+    options.field_of_view = 71.86
+    options.baseline = 7.5
+    options.swap_lr = True
 
     return options
 

--- a/calibrate.py
+++ b/calibrate.py
@@ -86,6 +86,8 @@ def parse_args():
                         help="Do not swap the Left and Right cameras.")
     parser.add_argument("-debug", "--dev_debug", default=None, action='store_true',
                         help="Used by board developers for debugging.")
+    parser.add_argument("-fusb2", "--force_usb2", default=False, action="store_true",
+                        help="Force usb2 connection")
     parser.add_argument("-iv", "--invert-vertical", dest="invert_v", default=False, action="store_true",
                         help="Invert vertical axis of the camera for the display")
     parser.add_argument("-ih", "--invert-horizontal", dest="invert_h", default=False, action="store_true",
@@ -220,7 +222,7 @@ class Main:
         pipeline = None
 
         try:
-            device = depthai.Device("", False)
+            device = depthai.Device("", self.args['force_usb2'])
             pipeline = device.create_pipeline(self.config)
         except RuntimeError:
             raise RuntimeError("Unable to initialize device. Try to reset it")

--- a/depthai_helpers/arg_manager.py
+++ b/depthai_helpers/arg_manager.py
@@ -115,21 +115,7 @@ class CliArgs:
 
         parser.add_argument("-lrc", "--stereo_lr_check", default=False, action="store_true",
                         help="Enable stereo 'Left-Right check' feature.")
-        parser.add_argument("-fv", "--field-of-view", default=None, type=float,
-                            help="Horizontal field of view (HFOV) for the stereo cameras in [deg]. Default: 71.86deg.")
 
-        parser.add_argument("-rfv", "--rgb-field-of-view", default=None, type=float,
-                            help="Horizontal field of view (HFOV) for the RGB camera in [deg]. Default: 68.7938deg.")
-
-        parser.add_argument("-b", "--baseline", default=None, type=float,
-                            help="Left/Right camera baseline in [cm]. Default: 9.0cm.")
-
-        parser.add_argument("-r", "--rgb-baseline", default=None, type=float,
-                            help="Distance the RGB camera is from the Left camera. Default: 2.0cm.")
-
-        parser.add_argument("-w", "--no-swap-lr", dest="swap_lr", default=None, action="store_false",
-                            help="Do not swap the Left and Right cameras.")
-        
         parser.add_argument("-e", "--store-eeprom", default=False, action="store_true",
                             help="Store the calibration and board_config (fov, baselines, swap-lr) in the EEPROM onboard")
         
@@ -207,17 +193,12 @@ class CliArgs:
         argcomplete.autocomplete(parser)
 
         options = parser.parse_args()
-        any_options_set = any([options.field_of_view, options.rgb_field_of_view, options.baseline, options.rgb_baseline,
-                               options.swap_lr])
-        if (options.board is not None) and any_options_set:
-            parser.error("[-brd] is mutually exclusive with [-fv -rfv -b -r -w]")
 
-        # Set some defaults after the above check
-        if not options.board:
-            options.field_of_view = 71.86
-            options.rgb_field_of_view = 68.7938
-            options.baseline = 9.0
-            options.rgb_baseline = 2.0
-            options.swap_lr = True
+        # Set some extra defaults, `-brd` would override them
+        options.field_of_view = 71.86
+        options.rgb_field_of_view = 68.7938
+        options.baseline = 7.5
+        options.rgb_baseline = 3.75
+        options.swap_lr = True
 
         return options

--- a/depthai_helpers/version_check.py
+++ b/depthai_helpers/version_check.py
@@ -22,7 +22,6 @@ def get_version_from_requirements():
 def check_depthai_version():
     version_required = get_version_from_requirements()
     if version_required is not None:
-        print('Depthai version required:  ', version_required)
         if depthai.__version__.endswith('+dev'):
             print('Depthai development version found, skipping check.')
         elif version_required != depthai.__version__:


### PR DESCRIPTION
- Add `-fusb2` option to `calibrate.py` - enabling a workaround for issue https://github.com/luxonis/depthai/issues/305 (cherry-picked the commit mentioned there)
- Remove command-line options that can use `-brd / --board` as a simpler/safer replacement (making sure no option is missed):
    - `-fv  / --field-of-view`
    - `-rfv / --rgb-field-of-view`
    - `-b   / --baseline`
    - `-r   / --rgb-baseline`
    - `-w   / --no-swap-lr`
- Set defaults to BW1098OBC / OAK-D if `-brd` is not specified
- Minor logging cleanup: don't print `Depthai required version` when it matches with `installed`, print just `installed`