### PR TITLE
Set default mono resolution to 400p; Limit 1st stage cnn choices

### DIFF
--- a/depthai_helpers/arg_manager.py
+++ b/depthai_helpers/arg_manager.py
@@ -100,7 +100,7 @@ class CliArgs:
         parser.add_argument("-cs", "--color_scale", default=1.0, type=float,
                             help="Scale factor for 'color' stream preview window. Default: %(default)s")
 
-        parser.add_argument("-monor", "--mono_resolution", default=720, type=int,  choices=[400, 720, 800],
+        parser.add_argument("-monor", "--mono_resolution", default=400, type=int,  choices=[400, 720, 800],
                             help="Mono cam res height: (1280x)720, (1280x)800 or (640x)400 - binning. Default: %(default)s")
 
         parser.add_argument("-monof", "--mono_fps", default=30.0, type=float,

--- a/depthai_helpers/arg_manager.py
+++ b/depthai_helpers/arg_manager.py
@@ -16,8 +16,8 @@ def _get_immediate_subdirectories(a_dir):
 
 _stream_choices = ("metaout", "previewout", "jpegout", "left", "right", "depth", "disparity", "disparity_color",
                    "meta_d2h", "object_tracker", "rectified_left", "rectified_right", "color")
-_CNN_choices = _get_immediate_subdirectories(consts.resource_paths.nn_resource_path)
 _CNN2_choices = ['landmarks-regression-retail-0009', 'facial-landmarks-35-adas-0002', 'emotions-recognition-retail-0003']
+_CNN_choices = [item for item in _get_immediate_subdirectories(consts.resource_paths.nn_resource_path) if item not in _CNN2_choices]
 
 def _stream_type(option):
     max_fps = None


### PR DESCRIPTION
'landmarks-regression-retail-0009', 'facial-landmarks-35-adas-0002', 'emotions-recognition-retail-0003'
are not supposed to be run as first stage networks.
Note: age-gender-recognition can't be run as second stage network due to gen1 limitations. (it has 2 tensor outputs)