### PR TITLE
Update Gen1 depthai: firmware fix for `-fusb2` on Windows

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ opencv-python==4.5.1.48
 requests==2.24.0
 argcomplete==1.12.1
 pyyaml==5.3.1
-depthai==0.4.1.1
+# depthai==0.4.1.1
 
-# --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/
-# depthai==0.4.1.1+91ba9cbf941592371a7246887a491f0c82632e9d
+--extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/
+depthai==0.4.1.1+d94e1b8e3a457dc2645d8ea9813057b569bbdd3a


### PR DESCRIPTION
USB descriptor was improperly set up, causing enumeration failure with `-fusb2` / `--force_usb2` on Windows (more strict checks).

It shouldn't affect the behavior on macOS or Linux.

On Linux for example, `dmesg` was just reporting `unable to get BOS descriptor`, but the device worked fine.
