### PR TITLE
add --report flag

### DIFF
--- a/depthai_demo.py
+++ b/depthai_demo.py
@@ -58,15 +58,19 @@ class Streams(enum.Enum):
         elif conf.args.camera == "color":
             return Streams.rgb
 
+
 def print_sys_info(info):
     m = 1024 * 1024 # MiB
-    print(f"Drr used / total - {info.ddrMemoryUsage.used / m:.2f} / {info.ddrMemoryUsage.total / m:.2f} MiB")
-    print(f"Cmx used / total - {info.cmxMemoryUsage.used / m:.2f} / {info.cmxMemoryUsage.total / m:.2f} MiB")
-    print(f"LeonCss heap used / total - {info.leonCssMemoryUsage.used / m:.2f} / {info.leonCssMemoryUsage.total / m:.2f} MiB")
-    print(f"LeonMss heap used / total - {info.leonMssMemoryUsage.used / m:.2f} / {info.leonMssMemoryUsage.total / m:.2f} MiB")
-    t = info.chipTemperature
-    print(f"Chip temperature - average: {t.average:.2f}, css: {t.css:.2f}, mss: {t.mss:.2f}, upa0: {t.upa:.2f}, upa1: {t.dss:.2f}")
-    print(f"Cpu usage - Leon OS: {info.leonCssCpuUsage.average * 100:.2f}%, Leon RT: {info.leonMssCpuUsage.average * 100:.2f} %")
+    if "memory" in conf.args.meta:
+        print(f"Drr used / total - {info.ddrMemoryUsage.used / m:.2f} / {info.ddrMemoryUsage.total / m:.2f} MiB")
+        print(f"Cmx used / total - {info.cmxMemoryUsage.used / m:.2f} / {info.cmxMemoryUsage.total / m:.2f} MiB")
+        print(f"LeonCss heap used / total - {info.leonCssMemoryUsage.used / m:.2f} / {info.leonCssMemoryUsage.total / m:.2f} MiB")
+        print(f"LeonMss heap used / total - {info.leonMssMemoryUsage.used / m:.2f} / {info.leonMssMemoryUsage.total / m:.2f} MiB")
+    if "temp" in conf.args.meta:
+        t = info.chipTemperature
+        print(f"Chip temperature - average: {t.average:.2f}, css: {t.css:.2f}, mss: {t.mss:.2f}, upa0: {t.upa:.2f}, upa1: {t.dss:.2f}")
+    if "cpu" in conf.args.meta:
+        print(f"Cpu usage - Leon OS: {info.leonCssCpuUsage.average * 100:.2f}%, Leon RT: {info.leonMssCpuUsage.average * 100:.2f} %")
     print("----------------------------------------")
 
 class NNetManager:
@@ -319,7 +323,7 @@ class PipelineManager:
         self.nodes.system_logger = self.p.createSystemLogger()
         self.nodes.system_logger.setRate(1)
 
-        if conf.args.meta:
+        if len(conf.args.meta) > 0:
             self.nodes.xout_system_logger = self.p.createXLinkOut()
             self.nodes.xout_system_logger.setStreamName("system_logger")
             self.nodes.system_logger.out.link(self.nodes.xout_system_logger.input)
@@ -351,7 +355,7 @@ with dai.Device(dai.OpenVINO.Version.VERSION_2021_3, device_info) as device:
     if conf.useDepth:
         pm.create_depth(conf.args.disparity_confidence_threshold, median, conf.args.stereo_lr_check)
 
-    if conf.args.meta:
+    if len(conf.args.meta) > 0:
         pm.create_system_logger()
 
     pm.create_nn()
@@ -364,7 +368,7 @@ with dai.Device(dai.OpenVINO.Version.VERSION_2021_3, device_info) as device:
 
     sbb_out = device.getOutputQueue("sbb", maxSize=1, blocking=False) if nn_manager.sbb else None
     depth_out = device.getOutputQueue("depth", maxSize=1, blocking=False) if conf.useDepth else None
-    log_out = device.getOutputQueue("system_logger", maxSize=30, blocking=False) if conf.args.meta else None
+    log_out = device.getOutputQueue("system_logger", maxSize=30, blocking=False) if len(conf.args.meta) > 0 else None
 
     current_stream = Streams.get_current_stream()
     cam_out = device.getOutputQueue(name=current_stream.name, maxSize=4, blocking=False) if conf.useCamera else None

--- a/depthai_helpers/arg_manager.py
+++ b/depthai_helpers/arg_manager.py
@@ -58,7 +58,7 @@ def parse_args():
                         help="Display spatial bounding box (ROI) when displaying spatial information. The Z coordinate get's calculated from the ROI (average)")
     parser.add_argument("-sbb-sf", "--sbb_scale_factor", default=0.3, type=float,
                         help="Spatial bounding box scale factor. Sometimes lower scale factor can give better depth (Z) result. Default: %(default)s")
-    parser.add_argument('--meta', action="store_true", help="Display device utilization data")
+    parser.add_argument('--meta', nargs="+", choices=["temp", "cpu", "memory"], help="Display device utilization data")
     parser.add_argument('-sync', '--sync', action="store_true",
                         help="Enable NN/camera synchronization. If enabled, camera source will be from the NN's passthrough attribute")
     parser.add_argument("-monor", "--mono_resolution", default=400, type=int, choices=[400,720,800],

--- a/depthai_helpers/arg_manager.py
+++ b/depthai_helpers/arg_manager.py
@@ -58,7 +58,8 @@ def parse_args():
                         help="Display spatial bounding box (ROI) when displaying spatial information. The Z coordinate get's calculated from the ROI (average)")
     parser.add_argument("-sbb-sf", "--sbb_scale_factor", default=0.3, type=float,
                         help="Spatial bounding box scale factor. Sometimes lower scale factor can give better depth (Z) result. Default: %(default)s")
-    parser.add_argument('--meta', nargs="+", choices=["temp", "cpu", "memory"], help="Display device utilization data")
+    parser.add_argument('--report', nargs="+", choices=["temp", "cpu", "memory"], help="Display device utilization data")
+    parser.add_argument('--report_file', help="Save report data to specified target file in CSV format")
     parser.add_argument('-sync', '--sync', action="store_true",
                         help="Enable NN/camera synchronization. If enabled, camera source will be from the NN's passthrough attribute")
     parser.add_argument("-monor", "--mono_resolution", default=400, type=int, choices=[400,720,800],

--- a/depthai_helpers/arg_manager.py
+++ b/depthai_helpers/arg_manager.py
@@ -58,6 +58,7 @@ def parse_args():
                         help="Display spatial bounding box (ROI) when displaying spatial information. The Z coordinate get's calculated from the ROI (average)")
     parser.add_argument("-sbb-sf", "--sbb_scale_factor", default=0.3, type=float,
                         help="Spatial bounding box scale factor. Sometimes lower scale factor can give better depth (Z) result. Default: %(default)s")
+    parser.add_argument('--meta', action="store_true", help="Display device utilization data")
     parser.add_argument('-sync', '--sync', action="store_true",
                         help="Enable NN/camera synchronization. If enabled, camera source will be from the NN's passthrough attribute")
     parser.add_argument("-monor", "--mono_resolution", default=400, type=int, choices=[400,720,800],


### PR DESCRIPTION
This flag allows to get DepthAI usage info on the terminal during the runtime.
Example output logs

```
Drr used / total - 75.58 / 414.55 MiB
Cmx used / total - 2.37 / 2.50 MiB
LeonCss heap used / total - 33.33 / 46.35 MiB
LeonMss heap used / total - 5.07 / 27.40 MiB
Chip temperature - average: 35.35, css: 36.06, mss: 34.64, upa0: 35.11, upa1: 35.59
Cpu usage - Leon OS: 27.15%, Leon RT: 1.70 %
----------------------------------------
Drr used / total - 75.58 / 414.55 MiB
Cmx used / total - 2.37 / 2.50 MiB
LeonCss heap used / total - 33.33 / 46.35 MiB
LeonMss heap used / total - 5.37 / 27.40 MiB
Chip temperature - average: 37.77, css: 38.88, mss: 37.24, upa0: 37.94, upa1: 37.01
Cpu usage - Leon OS: 27.33%, Leon RT: 23.24 %
----------------------------------------
Drr used / total - 75.58 / 414.55 MiB
Cmx used / total - 2.37 / 2.50 MiB
LeonCss heap used / total - 33.33 / 46.35 MiB
LeonMss heap used / total - 5.37 / 27.40 MiB
Chip temperature - average: 38.12, css: 39.58, mss: 36.53, upa0: 38.88, upa1: 37.48
Cpu usage - Leon OS: 50.82%, Leon RT: 32.86 %
----------------------------------------
Drr used / total - 75.58 / 414.55 MiB
Cmx used / total - 2.37 / 2.50 MiB
LeonCss heap used / total - 33.33 / 46.35 MiB
LeonMss heap used / total - 5.37 / 27.40 MiB
Chip temperature - average: 38.65, css: 39.11, mss: 38.18, upa0: 38.65, upa1: 38.65
Cpu usage - Leon OS: 56.26%, Leon RT: 38.27 %
----------------------------------------
```