### PR TITLE
Add custom callbacks support, allowing to customize demo script behaviour

### DIFF
--- a/callbacks.py
+++ b/callbacks.py
@@ -1,0 +1,26 @@
+def on_new_frame(frame, source):
+    pass
+
+
+def on_show_frame(frame, source):
+    pass
+
+
+def on_nn(nn_packet):
+    pass
+
+
+def on_report(report):
+    pass
+
+
+def on_setup(**kwargs):
+    pass
+
+
+def on_teardown(**kwargs):
+    pass
+
+
+def on_iter(**kwargs):
+    pass

--- a/depthai_helpers/arg_manager.py
+++ b/depthai_helpers/arg_manager.py
@@ -29,6 +29,7 @@ def check_range(min_val, max_val):
 
 _stream_choices = ("nn_input", "color", "left", "right", "depth", "disparity", "disparity_color", "rectified_left", "rectified_right")
 color_maps = list(map(lambda name: name[len("COLORMAP_"):], filter(lambda name: name.startswith("COLORMAP_"), vars(cv2))))
+project_root = Path(__file__).parent.parent
 
 def parse_args():
     parser = argparse.ArgumentParser()
@@ -80,4 +81,5 @@ def parse_args():
                         help="Mono cam res height: (1280x)720, (1280x)800 or (640x)400. Default: %(default)s")
     parser.add_argument("-monof", "--mono_fps", default=30.0, type=float,
                         help="Mono cam fps: max 60.0 for H:720 or H:800, max 120.0 for H:400. Default: %(default)s")
+    parser.add_argument('-cb', '--callback', type=Path, default=project_root / 'callbacks.py', help="Path to callbacks file to be used. Default: %(default)s")
     return parser.parse_args()

--- a/depthai_helpers/utils.py
+++ b/depthai_helpers/utils.py
@@ -1,3 +1,6 @@
+import importlib
+from pathlib import Path
+
 import cv2
 import numpy as np
 import depthai as dai
@@ -52,3 +55,10 @@ def merge(source, destination):
             destination[key] = value
 
     return destination
+
+
+def load_module(path: Path):
+    spec = importlib.util.spec_from_file_location(path.stem, str(path.absolute()))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module


### PR DESCRIPTION
This PR implements support for custom callbacks that users can add in order to customize the behavior of the demo script.

For example, if a user would like to add a label to each frame, that would indicate its origin, he can do it now without digging into a code, but modifying the `on_show_frame` method inside `callbacks.py` into the following

```python
from cv2 import cv2

# ...

def on_show_frame(frame, source):
    cv2.rectangle(frame, (frame.shape[1] - 100, frame.shape[0] - 30), (frame.shape[1], frame.shape[0]), (255, 255, 255), cv2.FILLED)
    cv2.putText(frame, source, (frame.shape[1] - 80, frame.shape[0] - 10), cv2.FONT_HERSHEY_TRIPLEX, 0.5, (0, 0, 0))

```

Which will result in the following output

![image](https://user-images.githubusercontent.com/5244214/118990199-f6a7a100-b982-11eb-95ee-9adaab4f9326.png)

Supported callbacks:

- `on_new_frame(frame, source)` - called when a new frame arrives from the device
- `on_show_frame(frame, source)` - called when a frame is about to be displayed
- `on_nn(nn_packet)` - called when a new nn packet is received
- `on_report(report)` - called when a new usage report is generated
- `on_setup(**kwargs)` - called when the demo script finished it's setup, with`kwargs` dictionary containing all variables inside the script. So, if someone would like e.g. to modify some attributes in PreviewManager, he can access it either using `kwargs["pv"]` (as `pv` is the variable name assigned to PreviewManager) or by changing the function definition to `on_setup(pv, **kwargs)` and use the `pv` parameter
- `on_teardown(**kwargs)` - called when the demo script is about to terminate
- `on_iter(**kwargs)` - called each time when a new iteration of the script's internal loop is started

Usage of `**kwargs` and `locals()` allows to pick just about anything from the script, so there is a very high degree of freedom in potential modifications