### PR TITLE
Add a better handling of misspelled model names when using model zoo

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ opencv-python==4.5.1.48; platform_machine != "aarch64"
 requests==2.24.0
 argcomplete==1.12.1
 pyyaml==5.4; platform_machine != "aarch64"
-blobconverter==0.0.9
+blobconverter==0.0.10
 depthai==2.3.0.0
 pytube==10.8.1
 


### PR DESCRIPTION
This PR is testable with the changes from #377, but changes a different part of the script. 

During tests of the mentioned PR, in one of the runs we misstyped `deeplabv3_person` (whereas the correct name should be deeplabv3**p**_person) in the cnn param, and it resulted with the following error

```
Traceback (most recent call last):
  File "depthai_demo.py", line 569, in <module>
    nn_manager = NNetManager(
  File "depthai_demo.py", line 195, in __init__
    self.blob_path = BlobManager(model_dir=self.model_dir, model_name=self.model_name).compile(conf.args.shaves)
  File "/home/erik/Luxonis/depthai/depthai_helpers/config_manager.py", line 287, in compile
    return blobconverter.from_zoo(name=self.model_name, shaves=shaves)
  File "/home/erik/.local/lib/python3.8/site-packages/blobconverter/__init__.py", line 265, in from_zoo
    return compile_blob(name, req_data=body, **kwargs)
  File "/home/erik/.local/lib/python3.8/site-packages/blobconverter/__init__.py", line 252, in compile_blob
    response.raise_for_status()
  File "/home/erik/.local/lib/python3.8/site-packages/requests/models.py", line 944, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 400 Client Error: BAD REQUEST for url: http://luxonis.com:8080/compile?version=2021.3
```

With no indication of what might be a cause of the error.

This PR adds both generic support for error messages (that prints the status code and response message) but also handles the model not found scenario specifically, as it also provides suggestion of the correct model name:

```
$ depthai_demo.py -cnn deeplabv3_person
Using depthai module from:  /home/vandavv/dev/luxonis/venvs/demo/lib/python3.8/site-packages/depthai.cpython-38-x86_64-linux-gnu.so
Depthai version installed:  2.3.0.0
Downloading /home/vandavv/.cache/blobconverter/deeplabv3_person_openvino_2021.3_13shave.blob...
Model deeplabv3_person not found in model zoo. Did you mean: deeplabv3p_person / deeplabv3 ?
```
