### PR TITLE
Add the ability to encode (record) camera output

### DIFF
--- a/depthai_demo.py
+++ b/depthai_demo.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import cv2
 import depthai as dai
 
-from depthai_helpers.managers import NNetManager, PreviewManager, FPSHandler, PipelineManager, Previews
+from depthai_helpers.managers import NNetManager, PreviewManager, FPSHandler, PipelineManager, Previews, EncodingManager
 from depthai_helpers.version_check import check_depthai_version
 import platform
 
@@ -130,7 +130,7 @@ with dai.Device(pm.p.getOpenVINOVersion(), device_info, usb2Mode=conf.args.usb_s
                 conf.args.subpixel,
             )
 
-        enc_manager = EncodingManager(pm) if len(conf.args.encode) > 0 else None
+        enc_manager = EncodingManager(pm, dict(conf.args.encode), conf.args.encode_output) if len(conf.args.encode) > 0 else None
 
     if len(conf.args.report) > 0:
         pm.create_system_logger()

--- a/depthai_demo.py
+++ b/depthai_demo.py
@@ -669,7 +669,6 @@ class EncodingManager():
                     )
                     print("Running conversion command... [{}]".format(ff.cmd))
                     ff.run()
-                    print("Done! Video ready: {}".format(out_name))
                 except ffmpy3.FFExecutableNotFoundError:
                     print("FFMPEG executable not found!")
                     traceback.print_exc()
@@ -678,6 +677,9 @@ class EncodingManager():
                     print("FFMPEG runtime error!")
                     traceback.print_exc()
                     print_manual()
+            for name, file in self.encoding_files.items():
+                print("Video conversion complete!")
+                print("Produced file: {}".format(str(Path(file.name).with_suffix('.mp4'))))
         except ImportError:
             print("Module ffmpy3 not found!")
             traceback.print_exc()

--- a/depthai_helpers/arg_manager.py
+++ b/depthai_helpers/arg_manager.py
@@ -54,7 +54,7 @@ color_maps = list(map(lambda name: name[len("COLORMAP_"):], filter(lambda name: 
 project_root = Path(__file__).parent.parent
 
 def parse_args():
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument('-cam', '--camera', choices=["left", "right", "color"], default="color", help="Use one of DepthAI cameras for inference (conflicts with -vid)")
     parser.add_argument('-vid', '--video', type=str, help="Path to video file (or YouTube link) to be used for inference (conflicts with -cam)")
     parser.add_argument('-hq', '--high_quality', action="store_true", default=False,

--- a/depthai_helpers/managers.py
+++ b/depthai_helpers/managers.py
@@ -1,5 +1,6 @@
 import json
 import time
+import traceback
 from functools import partial
 from pathlib import Path
 from types import SimpleNamespace
@@ -420,7 +421,7 @@ class PipelineManager:
         if not hasattr(self.nodes, 'mono_left'):
             raise RuntimeError("Left mono camera not initialized. Call create_left_cam(res, fps) first!")
         if not hasattr(self.nodes, 'mono_right'):
-            raise RuntimeError("Left mono camera not initialized. Call create_right_cam(res, fps) first!")
+            raise RuntimeError("Right mono camera not initialized. Call create_right_cam(res, fps) first!")
 
         self.nodes.mono_left.out.link(self.nodes.stereo.left)
         self.nodes.mono_right.out.link(self.nodes.stereo.right)
@@ -497,3 +498,107 @@ class PipelineManager:
         self.nodes.xout_system_logger = self.p.createXLinkOut()
         self.nodes.xout_system_logger.setStreamName("system_logger")
         self.nodes.system_logger.out.link(self.nodes.xout_system_logger.input)
+
+
+class EncodingManager:
+    def __init__(self, pm, encode_config: dict, encode_output=None):
+        self.encoding_queues = {}
+        self.encoding_nodes = {}
+        self.encoding_files = {}
+        self.encode_config = encode_config
+        self.encode_output = Path(encode_output) or Path(__file__).parent
+        self.pm = pm
+        for camera_name, enc_fps in self.encode_config.items():
+            self.create_encoder(camera_name, enc_fps)
+            self.encoding_nodes[camera_name] = getattr(pm.nodes, camera_name + "_enc")
+
+    def create_encoder(self, camera_name, enc_fps):
+        allowed_sources = [Previews.left.name, Previews.right.name, Previews.color.name]
+        if camera_name not in allowed_sources:
+            raise ValueError("Camera param invalid, received {}, available choices: {}".format(camera_name, allowed_sources))
+        node_name = camera_name.lower() + '_enc'
+        xout_name = node_name + "_xout"
+        enc_profile = dai.VideoEncoderProperties.Profile.H264_MAIN
+
+        if camera_name == Previews.color.name:
+            if not hasattr(self.pm.nodes, 'cam_rgb'):
+                raise RuntimeError("RGB camera not initialized. Call create_color_cam(res, fps) first!")
+            enc_resolution = (self.pm.nodes.cam_rgb.getResolutionWidth(), self.pm.nodes.pm.cam_rgb.getResolutionHeight())
+            enc_profile = dai.VideoEncoderProperties.Profile.H265_MAIN
+            enc_in = self.pm.nodes.cam_rgb.video
+
+        elif camera_name == Previews.left.name:
+            if not hasattr(self.pm.nodes, 'mono_left'):
+                raise RuntimeError("Left mono camera not initialized. Call create_left_cam(res, fps) first!")
+            enc_resolution = (self.pm.nodes.mono_left.getResolutionWidth(), self.pm.nodes.mono_left.getResolutionHeight())
+            enc_in = self.pm.nodes.mono_left.out
+        elif camera_name == Previews.right.name:
+            if not hasattr(self.pm.nodes, 'mono_right'):
+                raise RuntimeError("Right mono camera not initialized. Call create_right_cam(res, fps) first!")
+            enc_resolution = (self.pm.nodes.mono_right.getResolutionWidth(), self.pm.nodes.mono_right.getResolutionHeight())
+            enc_in = self.pm.nodes.mono_right.out
+        else:
+            raise NotImplementedError("Unable to create encoder for {]".format(camera_name))
+
+        enc = self.pm.p.createVideoEncoder()
+        enc.setDefaultProfilePreset(*enc_resolution, enc_fps, enc_profile)
+        enc_in.link(enc.input)
+        setattr(self.pm.nodes, node_name, enc)
+
+        enc_xout = self.pm.p.createXLinkOut()
+        enc.bitstream.link(enc_xout.input)
+        enc_xout.setStreamName(xout_name)
+        setattr(self.pm.nodes, xout_name, enc_xout)
+
+    def create_default_queues(self, device):
+        for camera_name, enc_fps in self.encode_config.items():
+            self.encoding_queues[camera_name] = device.getOutputQueue(camera_name + "_enc_xout", maxSize=30, blocking=True)
+            self.encoding_files[camera_name] = (self.encode_output / camera_name).with_suffix(
+                    ".h265" if self.encoding_nodes[camera_name].getProfile() == dai.VideoEncoderProperties.Profile.H265_MAIN else ".h264"
+                ).open('wb')
+
+    def parse_queues(self):
+        for name, queue in self.encoding_queues.items():
+            while queue.has():
+                queue.get().getData().tofile(self.encoding_files[name])
+
+    def close(self):
+        def print_manual():
+            print("To view the encoded data, convert the stream file (.h264/.h265) into a video file (.mp4), using commands below:")
+            cmd = "ffmpeg -framerate {} -i {} -c copy {}"
+            for name, file in self.encoding_files.items():
+                print(cmd.format(self.encoding_nodes[name].getFrameRate(), file.name, str(Path(file.name).with_suffix('.mp4'))))
+
+        for name, file in self.encoding_files.items():
+            file.close()
+        try:
+            import ffmpy3
+            for name, file in self.encoding_files.items():
+                fps = self.encoding_nodes[name].getFrameRate()
+                out_name = str(Path(file.name).with_suffix('.mp4'))
+                try:
+                    ff = ffmpy3.FFmpeg(
+                        inputs={file.name: "-y"},
+                        outputs={out_name: "-c copy -framerate {}".format(fps)}
+                    )
+                    print("Running conversion command... [{}]".format(ff.cmd))
+                    ff.run()
+                except ffmpy3.FFExecutableNotFoundError:
+                    print("FFMPEG executable not found!")
+                    traceback.print_exc()
+                    print_manual()
+                except ffmpy3.FFRuntimeError:
+                    print("FFMPEG runtime error!")
+                    traceback.print_exc()
+                    print_manual()
+            print("Video conversion complete!")
+            for name, file in self.encoding_files.items():
+                print("Produced file: {}".format(str(Path(file.name).with_suffix('.mp4'))))
+        except ImportError:
+            print("Module ffmpy3 not fouund!")
+            traceback.print_exc()
+            print_manual()
+        except:
+            print("Unknown error!")
+            traceback.print_exc()
+            print_manual()

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,1 +1,2 @@
 open3d==0.10.0.0; platform_machine != "armv7l" and python_version < "3.9"
+ffmpy3==git+git://github.com/VanDavv/ffmpy3.git@master;

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ requests==2.24.0
 argcomplete==1.12.1
 blobconverter==0.0.10
 depthai==2.5.0.0
+pytube==10.8.5


### PR DESCRIPTION
This PR adds two new flags:

- `-enc / --encode` flag that accepts the camera names to be recorded and also can contain their FPS (defaults to 30). You can pass either just `-enc left` (encode left camera with 30 FPS) or `-enc left right` (encode left and right camera with 30 FPS) or `-enc color left,10 right,10` (encode color camera with 30 FPS and left / right cameras with 10 FPS)
- `-encout / --encode_output` specifies path to the output directory where the encoded files will be stored (in a form of `<camera_name>.h264` )
```
$ ./depthai_demo.py --help
[...]
  -enc ENCODE [ENCODE ...], --encode ENCODE [ENCODE ...]
                        Define which cameras to encode (record) 
                        Format: camera_name or camera_name,enc_fps 
                        Example: -enc left color 
                        Example: -enc color right,10 left,10
  -encout ENCODE_OUTPUT, --encode_output ENCODE_OUTPUT
                        Path to directory where to store encoded files. Default: /home/vandavv/dev/luxonis/depthai
```