### PR TITLE
Install different opencv version for arm devices

### DIFF
--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,1 +1,1 @@
-open3d==0.10.0.0; platform_machine != "armv7l" and python_version < "3.9"
+open3d==0.10.0.0; platform_machine != "armv6l" and platform_machine != "armv7l" and python_version < "3.9"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
-opencv-python==4.5.1.48; platform_machine != "aarch64"
-opencv-contrib-python==4.5.1.48; platform_machine != "aarch64"
+opencv-python==4.5.1.48; platform_machine != "aarch64" and platform_machine != "armv6l" and platform_machine != "armv7l"
+opencv-contrib-python==4.5.1.48; platform_machine != "aarch64" and platform_machine != "armv6l" and platform_machine != "armv7l"
+opencv-python==4.4.0.46; platform_machine == "aarch64" or platform_machine == "armv6l" or platform_machine == "armv7l"
+opencv-contrib-python==4.4.0.46; platform_machine == "aarch64" or platform_machine == "armv6l" or platform_machine == "armv7l"
 requests==2.24.0
 argcomplete==1.12.1
-pyyaml==5.4; platform_machine != "aarch64"
 blobconverter==0.0.10
 depthai==2.5.0.0


### PR DESCRIPTION
Fixes [broken requirements](https://github.com/luxonis/depthai/pull/388/files#diff-4d7c51b1efe9043e44439a949dfd92e5827321b34082903477fd04876edb7552R2) for ARM devices (rpi2/3/zero)