### PR TITLE
Improve depth quality and allow real-time configuration

### DIFF
--- a/depthai_demo.py
+++ b/depthai_demo.py
@@ -9,7 +9,7 @@ from depthai_helpers.version_check import check_depthai_version
 import platform
 
 from depthai_helpers.arg_manager import parse_args
-from depthai_helpers.config_manager import BlobManager, ConfigManager
+from depthai_helpers.config_manager import ConfigManager
 from depthai_helpers.utils import frame_norm, to_planar, to_tensor_result, load_module
 
 print('Using depthai module from: ', dai.__file__)
@@ -132,11 +132,11 @@ with dai.Device(pm.p.getOpenVINOVersion(), device_info, usb2Mode=conf.args.usb_s
     if conf.useCamera or conf.args.sync:
         pv = PreviewManager(fps, display=conf.args.show, colorMap=conf.getColorMap(), disp_multiplier=disp_multiplier)
 
-        if conf.args.camera == "left" or conf.useDepth:
+        if conf.leftCameraEnabled:
             pm.create_left_cam(mono_res, conf.args.mono_fps)
-        if conf.args.camera == "right" or conf.useDepth:
+        if conf.rightCameraEnabled:
             pm.create_right_cam(mono_res, conf.args.mono_fps)
-        if conf.args.camera == "color":
+        if conf.rgbCameraEnabled:
             pm.create_color_cam(nn_manager.input_size if conf.useNN else (300, 300), rgb_res, conf.args.rgb_fps, conf.args.full_fov_nn, conf.useHQ)
 
         if conf.useDepth:

--- a/depthai_demo.py
+++ b/depthai_demo.py
@@ -180,8 +180,9 @@ with dai.Device(pm.p.getOpenVINOVersion(), device_info, usb2Mode=conf.args.usb_s
             if queue_name in [Previews.disparity_color.name, Previews.disparity.name, Previews.depth.name]:
                 Trackbars.create_trackbar('Disparity confidence', queue_name, 0, 255, conf.args.disparity_confidence_threshold,
                          lambda value: pm.update_depth_config(device, dct=value))
-                Trackbars.create_trackbar('Bilateral sigma', queue_name, 0, 250, conf.args.sigma,
-                         lambda value: pm.update_depth_config(device, sigma=value))
+                if queue_name == Previews.depth.name:
+                    Trackbars.create_trackbar('Bilateral sigma', queue_name, 0, 250, conf.args.sigma,
+                             lambda value: pm.update_depth_config(device, sigma=value))
                 if conf.args.stereo_lr_check:
                     Trackbars.create_trackbar('LR-check threshold', queue_name, 0, 10, conf.args.lrc_threshold,
                              lambda value: pm.update_depth_config(device, lrc_threshold=value))

--- a/depthai_demo.py
+++ b/depthai_demo.py
@@ -130,7 +130,7 @@ with dai.Device(pm.p.getOpenVINOVersion(), device_info, usb2Mode=conf.args.usb_s
     fps = FPSHandler() if conf.useCamera else FPSHandler(cap)
 
     if conf.useCamera or conf.args.sync:
-        pv = PreviewManager(fps, display=conf.args.show, colorMap=conf.getColorMap(), disp_multiplier=disp_multiplier)
+        pv = PreviewManager(fps, display=conf.args.show, colorMap=conf.getColorMap(), disp_multiplier=disp_multiplier, mouseTracker=True)
 
         if conf.leftCameraEnabled:
             pm.create_left_cam(mono_res, conf.args.mono_fps)

--- a/depthai_demo.py
+++ b/depthai_demo.py
@@ -235,16 +235,16 @@ with dai.Device(pm.p.getOpenVINOVersion(), device_info, usb2Mode=conf.args.usb_s
                     scaled_frame = cv2.resize(host_frame, nn_manager.input_size)
                     frame_nn = dai.ImgFrame()
                     frame_nn.setSequenceNum(seq_num)
-                    frame_nn.setType(dai.RawImgFrame.Type.BGR888p)
+                    frame_nn.setType(dai.ImgFrame.Type.BGR888p)
                     frame_nn.setWidth(nn_manager.input_size[0])
                     frame_nn.setHeight(nn_manager.input_size[1])
                     frame_nn.setData(to_planar(scaled_frame))
                     nn_in.send(frame_nn)
                     seq_num += 1
 
-                # if high quality, send original frames
-                if not conf.useHQ:
-                    host_frame = scaled_frame
+                    # if high quality, send original frames
+                    if not conf.useHQ:
+                        host_frame = scaled_frame
                 fps.tick('host')
 
             if nn_out is not None:

--- a/depthai_demo.py
+++ b/depthai_demo.py
@@ -109,11 +109,9 @@ if conf.args.openvino_version:
     openvino_version = getattr(dai.OpenVINO.Version, 'VERSION_' + conf.args.openvino_version)
 pm = PipelineManager(openvino_version)
 
-input_size = tuple(map(int, conf.args.cnn_input_size.split('x'))) if conf.args.cnn_input_size else None
-
 if conf.useNN:
     nn_manager = NNetManager(
-        input_size=input_size,
+        input_size=conf.inputSize,
         model_name=conf.getModelName(),
         model_dir=conf.getModelDir(),
         source=conf.getModelSource(),
@@ -137,7 +135,7 @@ with dai.Device(pm.p.getOpenVINOVersion(), device_info, usb2Mode=conf.args.usb_s
         if conf.rightCameraEnabled:
             pm.create_right_cam(mono_res, conf.args.mono_fps)
         if conf.rgbCameraEnabled:
-            pm.create_color_cam(nn_manager.input_size if conf.useNN else (300, 300), rgb_res, conf.args.rgb_fps, conf.args.full_fov_nn, conf.useHQ)
+            pm.create_color_cam(nn_manager.input_size if conf.useNN else conf.previewSize, rgb_res, conf.args.rgb_fps, conf.args.full_fov_nn, conf.useHQ)
 
         if conf.useDepth:
             pm.create_depth(

--- a/depthai_demo.py
+++ b/depthai_demo.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import os
 from itertools import cycle
 from pathlib import Path
 import cv2
@@ -11,6 +12,13 @@ import platform
 from depthai_helpers.arg_manager import parse_args
 from depthai_helpers.config_manager import ConfigManager
 from depthai_helpers.utils import frame_norm, to_planar, to_tensor_result, load_module
+
+DISP_CONF_MIN = int(os.getenv("DISP_CONF_MIN", 0))
+DISP_CONF_MAX = int(os.getenv("DISP_CONF_MAX", 255))
+SIGMA_MIN = int(os.getenv("SIGMA_MIN", 0))
+SIGMA_MAX = int(os.getenv("SIGMA_MAX", 250))
+LRCT_MIN = int(os.getenv("LRCT_MIN", 0))
+LRCT_MAX = int(os.getenv("LRCT_MAX", 10))
 
 print('Using depthai module from: ', dai.__file__)
 print('Depthai version installed: ', dai.__version__)
@@ -182,13 +190,13 @@ with dai.Device(pm.p.getOpenVINOVersion(), device_info, usb2Mode=conf.args.usb_s
     if conf.useCamera:
         def create_queue_callback(queue_name):
             if queue_name in [Previews.disparity_color.name, Previews.disparity.name, Previews.depth.name, Previews.depth_raw.name]:
-                Trackbars.create_trackbar('Disparity confidence', queue_name, 0, 255, conf.args.disparity_confidence_threshold,
+                Trackbars.create_trackbar('Disparity confidence', queue_name, DISP_CONF_MIN, DISP_CONF_MAX, conf.args.disparity_confidence_threshold,
                          lambda value: pm.update_depth_config(device, dct=value))
                 if queue_name in [Previews.depth_raw.name, Previews.depth.name]:
-                    Trackbars.create_trackbar('Bilateral sigma', queue_name, 0, 250, conf.args.sigma,
+                    Trackbars.create_trackbar('Bilateral sigma', queue_name, SIGMA_MIN, SIGMA_MAX, conf.args.sigma,
                              lambda value: pm.update_depth_config(device, sigma=value))
                 if conf.args.stereo_lr_check:
-                    Trackbars.create_trackbar('LR-check threshold', queue_name, 0, 10, conf.args.lrc_threshold,
+                    Trackbars.create_trackbar('LR-check threshold', queue_name, LRCT_MIN, LRCT_MAX, conf.args.lrc_threshold,
                              lambda value: pm.update_depth_config(device, lrc_threshold=value))
         pv.create_queues(device, create_queue_callback)
         if enc_manager is not None:

--- a/depthai_helpers/arg_manager.py
+++ b/depthai_helpers/arg_manager.py
@@ -60,6 +60,7 @@ def parse_args():
     parser.add_argument('-hq', '--high_quality', action="store_true", default=False,
                         help="Low quality visualization - uses resized frames")
     parser.add_argument('-dd', '--disable_depth', action="store_true", help="Disable depth information")
+    parser.add_argument('-dnn', '--disable_neural_network', action="store_true", help="Disable neural network inference")
     parser.add_argument('-cnnp', '--cnn_path', type=Path, help="Path to cnn model directory to be run")
     parser.add_argument("-cnn", "--cnn_model", default="mobilenet-ssd", type=str,
                         help="Cnn model to run on DepthAI")

--- a/depthai_helpers/arg_manager.py
+++ b/depthai_helpers/arg_manager.py
@@ -49,7 +49,7 @@ def _coma_separated(default, cast=str):
 
 
 openvino_versions = list(map(lambda name: name.replace("VERSION_", ""), filter(lambda name: name.startswith("VERSION_"), vars(dai.OpenVINO.Version))))
-_stream_choices = ("nn_input", "color", "left", "right", "depth", "disparity", "disparity_color", "rectified_left", "rectified_right")
+_stream_choices = ("nn_input", "color", "left", "right", "depth", "depth_raw", "disparity", "disparity_color", "rectified_left", "rectified_right")
 color_maps = list(map(lambda name: name[len("COLORMAP_"):], filter(lambda name: name.startswith("COLORMAP_"), vars(cv2))))
 project_root = Path(__file__).parent.parent
 

--- a/depthai_helpers/arg_manager.py
+++ b/depthai_helpers/arg_manager.py
@@ -73,6 +73,10 @@ def parse_args():
                         help="RGB cam fps: max 118.0 for H:1080, max 42.0 for H:2160. Default: %(default)s")
     parser.add_argument("-dct", "--disparity_confidence_threshold", default=245, type=check_range(0, 255),
                         help="Disparity confidence threshold, used for depth measurement. Default: %(default)s")
+    parser.add_argument("-lrct", "--lrc_threshold", default=4, type=check_range(0, 10),
+                        help="Left right check threshold, used for depth measurement. Default: %(default)s")
+    parser.add_argument("-sig", "--sigma", default=0, type=check_range(0, 250),
+                        help="Sigma value for Bilateral Filter applied on depth. Default: %(default)s")
     parser.add_argument("-med", "--stereo_median_size", default=7, type=int, choices=[0, 3, 5, 7],
                         help="Disparity / depth median filter kernel size (N x N) . 0 = filtering disabled. Default: %(default)s")
     parser.add_argument('-lrc', '--stereo_lr_check', action="store_true",

--- a/depthai_helpers/arg_manager.py
+++ b/depthai_helpers/arg_manager.py
@@ -7,6 +7,7 @@ try:
     import argcomplete
 except ImportError:
     raise ImportError('\033[1;5;31m argcomplete module not found, run: python3 install_requirements.py \033[0m')
+from depthai_helpers.managers import Previews
 
 
 def get_immediate_subdirectories(a_dir):
@@ -55,7 +56,7 @@ project_root = Path(__file__).parent.parent
 
 def parse_args():
     parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
-    parser.add_argument('-cam', '--camera', choices=["left", "right", "color"], default="color", help="Use one of DepthAI cameras for inference (conflicts with -vid)")
+    parser.add_argument('-cam', '--camera', choices=[Previews.left.name, Previews.right.name, Previews.color.name], default=Previews.color.name, help="Use one of DepthAI cameras for inference (conflicts with -vid)")
     parser.add_argument('-vid', '--video', type=str, help="Path to video file (or YouTube link) to be used for inference (conflicts with -cam)")
     parser.add_argument('-hq', '--high_quality', action="store_true", default=False,
                         help="Low quality visualization - uses resized frames")

--- a/depthai_helpers/config_manager.py
+++ b/depthai_helpers/config_manager.py
@@ -3,25 +3,24 @@ import platform
 import subprocess
 import sys
 import urllib.request
-from difflib import get_close_matches
 from pathlib import Path
 
 import cv2
 import depthai as dai
 
-import blobconverter
-
 from depthai_helpers.cli_utils import cli_print, PrintColors
-
-DEPTHAI_ZOO = Path(__file__).parent.parent / Path(f"resources/nn/")
-DEPTHAI_VIDEOS = Path(__file__).parent.parent / Path(f"videos/")
-DEPTHAI_VIDEOS.mkdir(exist_ok=True)
+from depthai_helpers.managers import Previews
 
 
 def show_progress(curr, max):
     done = int(50 * curr / max)
     sys.stdout.write("\r[{}{}] ".format('=' * done, ' ' * (50-done)) )
     sys.stdout.flush()
+
+
+DEPTHAI_ZOO = Path(__file__).parent.parent / Path(f"resources/nn/")
+DEPTHAI_VIDEOS = Path(__file__).parent.parent / Path(f"videos/")
+DEPTHAI_VIDEOS.mkdir(exist_ok=True)
 
 
 class ConfigManager:
@@ -108,6 +107,8 @@ class ConfigManager:
             return dai.MonoCameraProperties.SensorResolution.THE_400_P
 
     def getMedianFilter(self):
+        if self.args.subpixel:
+            return dai.MedianFilter.MEDIAN_OFF
         if self.args.stereo_median_size == 3:
             return dai.MedianFilter.KERNEL_3x3
         elif self.args.stereo_median_size == 5:
@@ -275,69 +276,23 @@ class ConfigManager:
             return obj
         else: return self.args.count_label.lower()
 
+    @property
+    def leftCameraEnabled(self):
+        return (self.args.camera == Previews.left.name and self.useNN) or \
+               Previews.left.name in self.args.show or \
+               Previews.rectified_left.name in self.args.show or \
+               self.useDepth
 
-class BlobManager:
-    def __init__(self, model_name=None, model_dir=None):
-        self.model_dir = None
-        self.zoo_dir = None
-        self.config_file = None
-        self.blob_path = None
-        self.use_zoo = False
-        self.use_blob = False
-        self.zoo_models = [f.stem for f in DEPTHAI_ZOO.iterdir() if f.is_dir()]
-        if model_dir is None:
-            self.model_name = model_name
-            self.use_zoo = True
-        else:
-            self.model_dir = Path(model_dir)
-            self.zoo_dir = self.model_dir.parent
-            self.model_name = model_name or self.model_dir.name
-            self.config_file = self.model_dir / "model.yml"
-            blob = next(self.model_dir.glob("*.blob"), None)
-            if blob is not None:
-                self.use_blob = True
-                self.blob_path = blob
-            if not self.config_file.exists():
-                self.use_zoo = True
+    @property
+    def rightCameraEnabled(self):
+        return (self.args.camera == Previews.right.name and self.useNN) or \
+               Previews.left.name in self.args.show or \
+               Previews.rectified_left.name in self.args.show or \
+               self.useDepth
+
+    @property
+    def rgbCameraEnabled(self):
+        return (self.args.camera == Previews.color.name and self.useNN) or \
+               Previews.color.name in self.args.show
 
 
-    def compile(self, shaves, openvino_version, target='auto'):
-        version = openvino_version.name.replace("VERSION_", "").replace("_", ".")
-        if self.use_blob:
-            return self.blob_path
-        elif self.use_zoo:
-            try:
-                self.blob_path = blobconverter.from_zoo(
-                    name=self.model_name,
-                    shaves=shaves,
-                    version=version
-                )
-                return self.blob_path
-            except Exception as e:
-                if hasattr(e, 'response') and hasattr(e.response, 'status_code'):
-                    if "not found in model zoo" in e.response.text:
-                        all_models = set(self.zoo_models + blobconverter.zoo_list())
-                        suggested = get_close_matches(self.model_name, all_models)
-                        if len(suggested) > 0:
-                            print("Model {} not found in model zoo. Did you mean: {} ?".format(self.model_name, " / ".join(suggested)), file=sys.stderr)
-                        else:
-                            print("Model {} not found in model zoo", file=sys.stderr)
-                        raise SystemExit(1)
-                    raise RuntimeError("Blob conversion failed with status {}! Error: \"{}\"".format(e.response.status_code, e.response.text))
-                else:
-                    raise
-        else:
-            self.blob_path = blobconverter.compile_blob(
-                version=version,
-                blob_name=self.model_name,
-                req_data={
-                    "name": self.model_name,
-                    "use_zoo": True,
-                },
-                req_files={
-                    'config': self.config_file,
-                },
-                data_type="FP16",
-                shaves=shaves,
-            )
-            return self.blob_path

--- a/depthai_helpers/config_manager.py
+++ b/depthai_helpers/config_manager.py
@@ -40,6 +40,10 @@ class ConfigManager:
         return not self.args.video
 
     @property
+    def useNN(self):
+        return not self.args.disable_neural_network
+
+    @property
     def useHQ(self):
         return self.args.high_quality
 

--- a/depthai_helpers/config_manager.py
+++ b/depthai_helpers/config_manager.py
@@ -105,13 +105,13 @@ class ConfigManager:
 
     def getMedianFilter(self):
         if self.args.stereo_median_size == 3:
-            return dai.StereoDepthProperties.MedianFilter.KERNEL_3x3
+            return dai.MedianFilter.KERNEL_3x3
         elif self.args.stereo_median_size == 5:
-            return dai.StereoDepthProperties.MedianFilter.KERNEL_5x5
+            return dai.MedianFilter.KERNEL_5x5
         elif self.args.stereo_median_size == 7:
-            return dai.StereoDepthProperties.MedianFilter.KERNEL_7x7
+            return dai.MedianFilter.KERNEL_7x7
         else:
-            return dai.StereoDepthProperties.MedianFilter.MEDIAN_OFF
+            return dai.MedianFilter.MEDIAN_OFF
 
     def getUsb2Mode(self):
         usb2_mode = False
@@ -191,6 +191,9 @@ class ConfigManager:
         self.args.video = path
 
     def adjustPreviewToOptions(self):
+        if len(self.args.show) != 0:
+            return
+
         if self.args.camera == "color" and "color" not in self.args.show:
             self.args.show.append("color")
         if self.args.camera == "left" and "left" not in self.args.show:

--- a/depthai_helpers/config_manager.py
+++ b/depthai_helpers/config_manager.py
@@ -298,4 +298,12 @@ class ConfigManager:
         return (self.args.camera == Previews.color.name and self.useNN) or \
                Previews.color.name in self.args.show
 
+    @property
+    def inputSize(self):
+        return tuple(map(int, self.args.cnn_input_size.split('x'))) if self.args.cnn_input_size else None
+
+    @property
+    def previewSize(self):
+        return self.inputSize or (576, 324)
+
 

--- a/depthai_helpers/config_manager.py
+++ b/depthai_helpers/config_manager.py
@@ -228,6 +228,9 @@ class ConfigManager:
                     updated_show_arg.append(name)
                 else:
                     print("Disabling {} preview...".format(name))
+            if len(updated_show_arg) == 0:
+                print("No previews available, adding color...")
+                updated_show_arg.append("color")
             self.args.show = updated_show_arg
 
     def linuxCheckApplyUsbRules(self):

--- a/depthai_helpers/managers.py
+++ b/depthai_helpers/managers.py
@@ -32,7 +32,8 @@ def convert_depth_raw_to_depth(depth_raw, manager):
         focal = depth_raw.shape[1] / (2. * math.tan(math.radians(fov / 2)))
         dispScaleFactor = baseline * focal
         setattr(manager, "dispScaleFactor", dispScaleFactor)
-    disp_frame = dispScaleFactor / depth_raw
+    with np.errstate(divide='ignore'):  # Should be safe to ignore div by zero here
+        disp_frame = dispScaleFactor / depth_raw
     disp_frame = (disp_frame * manager.disp_multiplier).astype(np.uint8)
     return convert_disparity_to_color(disp_frame, manager)
 

--- a/depthai_helpers/managers.py
+++ b/depthai_helpers/managers.py
@@ -136,7 +136,10 @@ class MouseClickTracker:
 
     def extract_value(self, name, frame: np.ndarray):
         if self.point is not None:
-            self.values[name] = frame[self.point[1]][self.point[0]].copy()
+            try:
+                self.values[name] = frame[self.point[1]][self.point[0]].copy()
+            except:
+                pass
 
 
 class PreviewManager:

--- a/depthai_helpers/managers.py
+++ b/depthai_helpers/managers.py
@@ -191,15 +191,18 @@ class PreviewManager:
 
     def prepare_frames(self, callback):
         for queue in self.output_queues:
-            frame = queue.tryGet()
-            if frame is not None:
+            packet = queue.tryGet()
+            if packet is not None:
                 self.fps.tick(queue.getName())
-                frame = getattr(Previews, queue.getName()).value(frame, self)
+                frame = getattr(Previews, queue.getName()).value(packet, self)
                 if queue.getName() in self.display:
                     callback(frame, queue.getName())
                     self.raw_frames[queue.getName()] = frame
                 if self.mouse_tracker is not None:
-                    self.mouse_tracker.extract_value(queue.getName(), frame)
+                    if queue.getName() in (Previews.disparity.name, Previews.depth_raw.name):
+                        self.mouse_tracker.extract_value(queue.getName(), packet.getFrame())
+                    else:
+                        self.mouse_tracker.extract_value(queue.getName(), frame)
 
                 if queue.getName() == Previews.disparity.name and Previews.disparity_color.name in self.display:
                     self.fps.tick(Previews.disparity_color.name)

--- a/depthai_helpers/managers.py
+++ b/depthai_helpers/managers.py
@@ -1,17 +1,19 @@
 import json
 import math
+import sys
 import time
 import traceback
+from difflib import get_close_matches
 from functools import partial
 from pathlib import Path
 from types import SimpleNamespace
 
+import blobconverter
 import cv2
 import depthai as dai
 import numpy as np
 
 import enum
-from depthai_helpers.config_manager import BlobManager
 from depthai_helpers.utils import load_module, frame_norm, to_tensor_result
 
 
@@ -36,6 +38,72 @@ def convert_depth_raw_to_depth(depth_raw, manager):
         disp_frame = dispScaleFactor / depth_raw
     disp_frame = (disp_frame * manager.disp_multiplier).astype(np.uint8)
     return convert_disparity_to_color(disp_frame, manager)
+
+
+class BlobManager:
+    def __init__(self, model_name=None, model_dir:Path=None):
+        self.model_dir = None
+        self.zoo_dir = None
+        self.config_file = None
+        self.blob_path = None
+        self.use_zoo = False
+        self.use_blob = False
+        self.zoo_models = [f.stem for f in model_dir.parent.iterdir() if f.is_dir()] if model_dir is not None else []
+        if model_dir is None:
+            self.model_name = model_name
+            self.use_zoo = True
+        else:
+            self.model_dir = Path(model_dir)
+            self.zoo_dir = self.model_dir.parent
+            self.model_name = model_name or self.model_dir.name
+            self.config_file = self.model_dir / "model.yml"
+            blob = next(self.model_dir.glob("*.blob"), None)
+            if blob is not None:
+                self.use_blob = True
+                self.blob_path = blob
+            if not self.config_file.exists():
+                self.use_zoo = True
+
+    def compile(self, shaves, openvino_version, target='auto'):
+        version = openvino_version.name.replace("VERSION_", "").replace("_", ".")
+        if self.use_blob:
+            return self.blob_path
+        elif self.use_zoo:
+            try:
+                self.blob_path = blobconverter.from_zoo(
+                    name=self.model_name,
+                    shaves=shaves,
+                    version=version
+                )
+                return self.blob_path
+            except Exception as e:
+                if hasattr(e, 'response') and hasattr(e.response, 'status_code'):
+                    if "not found in model zoo" in e.response.text:
+                        all_models = set(self.zoo_models + blobconverter.zoo_list())
+                        suggested = get_close_matches(self.model_name, all_models)
+                        if len(suggested) > 0:
+                            print("Model {} not found in model zoo. Did you mean: {} ?".format(self.model_name, " / ".join(suggested)), file=sys.stderr)
+                        else:
+                            print("Model {} not found in model zoo", file=sys.stderr)
+                        raise SystemExit(1)
+                    raise RuntimeError("Blob conversion failed with status {}! Error: \"{}\"".format(e.response.status_code, e.response.text))
+                else:
+                    raise
+        else:
+            self.blob_path = blobconverter.compile_blob(
+                version=version,
+                blob_name=self.model_name,
+                req_data={
+                    "name": self.model_name,
+                    "use_zoo": True,
+                },
+                req_files={
+                    'config': self.config_file,
+                },
+                data_type="FP16",
+                shaves=shaves,
+            )
+            return self.blob_path
 
 
 class Previews(enum.Enum):

--- a/depthai_helpers/managers.py
+++ b/depthai_helpers/managers.py
@@ -121,14 +121,33 @@ class Previews(enum.Enum):
     disparity_color = partial(convert_disparity_to_color)
 
 
+class MouseClickTracker:
+    def __init__(self):
+        self.point = None
+        self.values = {}
+
+    def select_point(self, event, x, y, flags, param):
+        if event == cv2.EVENT_LBUTTONUP:
+            self.values = {}
+            if self.point == (x, y):
+                self.point = None
+            else:
+                self.point = (x, y)
+
+    def extract_value(self, name, frame: np.ndarray):
+        if self.point is not None:
+            self.values[name] = frame[self.point[1]][self.point[0]].copy()
+
+
 class PreviewManager:
-    def __init__(self, fps, display, colorMap=cv2.COLORMAP_JET, disp_multiplier=255/96):
+    def __init__(self, fps, display, colorMap=cv2.COLORMAP_JET, disp_multiplier=255/96, mouseTracker=False):
         self.display = display
         self.frames = {}
         self.raw_frames = {}
         self.fps = fps
         self.colorMap = colorMap
         self.disp_multiplier = disp_multiplier
+        self.mouse_tracker = MouseClickTracker() if mouseTracker else None
 
     def create_queues(self, device, callback=lambda *a, **k: None):
         calib = device.readCalibration()
@@ -141,6 +160,8 @@ class PreviewManager:
         self.output_queues = []
         for name in self.display:
             cv2.namedWindow(name)
+            if self.mouse_tracker is not None:
+                cv2.setMouseCallback(name, self.mouse_tracker.select_point)
             callback(name)
             if name not in (Previews.disparity_color.name, Previews.depth.name):  # generated on host
                 self.output_queues.append(device.getOutputQueue(name=name, maxSize=1, blocking=False))
@@ -158,23 +179,39 @@ class PreviewManager:
                 if queue.getName() in self.display:
                     callback(frame, queue.getName())
                     self.raw_frames[queue.getName()] = frame
+                    if self.mouse_tracker is not None:
+                        self.mouse_tracker.extract_value(queue.getName(), frame)
+                        print(self.mouse_tracker.values)
 
                 if queue.getName() == Previews.disparity.name and Previews.disparity_color.name in self.display:
                     self.fps.tick(Previews.disparity_color.name)
                     self.raw_frames[Previews.disparity_color.name] = Previews.disparity_color.value(frame, self)
+                    if self.mouse_tracker is not None:
+                        self.mouse_tracker.extract_value(Previews.disparity_color.name, frame)
 
                 if queue.getName() == Previews.depth_raw.name and Previews.depth.name in self.display:
                     self.fps.tick(Previews.depth.name)
                     self.raw_frames[Previews.depth.name] = Previews.depth.value(frame, self)
+                    self.raw_frames[Previews.depth_raw.name] = self.raw_frames[Previews.depth_raw.name].copy()
+                    print(self.raw_frames[Previews.depth_raw.name].dtype)
+                    if self.mouse_tracker is not None:
+                        self.mouse_tracker.extract_value(Previews.depth.name, frame)
 
             for name in self.raw_frames:
-                self.frames[name] = self.raw_frames[name].copy()
+                new_frame = self.raw_frames[name].copy()
+                if name == Previews.depth_raw.name:
+                    new_frame = cv2.normalize(new_frame, None, 255, 0, cv2.NORM_INF, cv2.CV_8UC1)
+                self.frames[name] = new_frame
 
     def show_frames(self, scale=1.0, callback=lambda *a, **k: None):
         for name, frame in self.frames.items():
             if not scale == 1.0:
                 h, w, c = frame.shape
                 frame = cv2.resize(frame, (int(w * scale), int(h * scale)), interpolation=cv2.INTER_AREA)
+
+            if self.mouse_tracker is not None and name in self.mouse_tracker.values:
+                cv2.circle(frame, self.mouse_tracker.point, 3, (255, 255, 255), -1)
+                cv2.putText(frame, str(self.mouse_tracker.values[name]), self.mouse_tracker.point, cv2.FONT_HERSHEY_TRIPLEX, 0.5, (255, 255, 255))
             return_frame = callback(frame, name)  # Can be None, can be other frame e.g. after copy()
             cv2.imshow(name, return_frame if return_frame is not None else frame)
 

--- a/depthai_helpers/managers.py
+++ b/depthai_helpers/managers.py
@@ -31,7 +31,7 @@ def convert_depth_raw_to_depth(depth_raw, manager=None):
     if dispScaleFactor is None:
         baseline = getattr(manager, 'baseline', 75)  # mm
         fov = getattr(manager, 'fov', 71.86)
-        focal = getattr(manager, 'focal', depth_raw.shape[1] / (2. * math.tan(math.radians(fov / 2))))
+        focal = getattr(manager, 'focal', depth_raw.shapesin[1] / (2. * math.tan(math.radians(fov / 2))))
         dispScaleFactor = baseline * focal
         if manager is not None:
             setattr(manager, "dispScaleFactor", dispScaleFactor)
@@ -167,7 +167,7 @@ class PreviewManager:
             calib = device.readCalibration()
             eeprom = calib.getEepromData()
             cam_info = eeprom.cameraData[calib.getStereoLeftCameraId()]
-            self.baseline = cam_info.extrinsics.specTranslation.x * 10  # cm -> mm
+            self.baseline = abs(cam_info.extrinsics.specTranslation.x * 10)  # cm -> mm
             self.fov = calib.getFov(calib.getStereoLeftCameraId())
             self.focal = (cam_info.width / 2) / (2. * math.tan(math.radians(self.fov / 2)))
             self.dispScaleFactor = self.baseline * self.focal

--- a/depthai_helpers/managers.py
+++ b/depthai_helpers/managers.py
@@ -192,8 +192,6 @@ class PreviewManager:
                 if queue.getName() == Previews.depth_raw.name and Previews.depth.name in self.display:
                     self.fps.tick(Previews.depth.name)
                     self.raw_frames[Previews.depth.name] = Previews.depth.value(frame, self)
-                    self.raw_frames[Previews.depth_raw.name] = self.raw_frames[Previews.depth_raw.name].copy()
-                    print(self.raw_frames[Previews.depth_raw.name].dtype)
                     if self.mouse_tracker is not None:
                         self.mouse_tracker.extract_value(Previews.depth.name, frame)
 

--- a/depthai_helpers/managers.py
+++ b/depthai_helpers/managers.py
@@ -62,7 +62,7 @@ class PreviewManager:
         for name in self.display:
             cv2.namedWindow(name)
             callback(name)
-            if name != Previews.disparity_color.name:
+            if name != Previews.disparity_color.name:  # Disparity color frame is generated on host
                 self.output_queues.append(device.getOutputQueue(name=name, maxSize=1, blocking=False))
 
     def prepare_frames(self, callback):

--- a/depthai_helpers/managers.py
+++ b/depthai_helpers/managers.py
@@ -181,7 +181,6 @@ class PreviewManager:
                     self.raw_frames[queue.getName()] = frame
                     if self.mouse_tracker is not None:
                         self.mouse_tracker.extract_value(queue.getName(), frame)
-                        print(self.mouse_tracker.values)
 
                 if queue.getName() == Previews.disparity.name and Previews.disparity_color.name in self.display:
                     self.fps.tick(Previews.disparity_color.name)

--- a/depthai_helpers/managers.py
+++ b/depthai_helpers/managers.py
@@ -15,14 +15,8 @@ from depthai_helpers.utils import load_module, frame_norm, to_tensor_result
 
 
 def convert_depth_frame(packet, manager):
-    raw_frame = packet.getFrame()
-    min_d, max_d = np.quantile(raw_frame, [0.05, 0.95])
-    if max_d == min_d:
-        max_d = 65535
-    factor = 255 / (max_d - min_d)
-    init_offset = min_d
-
-    depth_frame = ((raw_frame - init_offset) * factor).astype(np.uint8)
+    depth_frame = cv2.normalize(packet.getFrame(), None, 255, 0, cv2.NORM_INF, cv2.CV_8UC1)
+    depth_frame = cv2.equalizeHist(depth_frame)
     depth_frame = cv2.applyColorMap(depth_frame, manager.colorMap)
     return depth_frame
 
@@ -34,6 +28,7 @@ def convert_disparity_frame(packet, manager):
 
 def convert_disparity_to_color(disparity, manager):
     return cv2.applyColorMap(disparity, manager.colorMap)
+
 
 class Previews(enum.Enum):
     nn_input = partial(lambda packet, _: packet.getCvFrame())

--- a/depthai_helpers/managers.py
+++ b/depthai_helpers/managers.py
@@ -163,13 +163,14 @@ class PreviewManager:
         self.mouse_tracker = MouseClickTracker() if mouseTracker else None
 
     def create_queues(self, device, callback=lambda *a, **k: None):
-        calib = device.readCalibration()
-        eeprom = calib.getEepromData()
-        cam_info = eeprom.cameraData[calib.getStereoLeftCameraId()]
-        self.baseline = cam_info.extrinsics.specTranslation.x * 10  # cm -> mm
-        self.fov = calib.getFov(calib.getStereoLeftCameraId())
-        self.focal = (cam_info.width / 2) / (2. * math.tan(math.radians(self.fov / 2)))
-        self.dispScaleFactor = self.baseline * self.focal
+        if dai.CameraBoardSocket.LEFT in device.getConnectedCameras():
+            calib = device.readCalibration()
+            eeprom = calib.getEepromData()
+            cam_info = eeprom.cameraData[calib.getStereoLeftCameraId()]
+            self.baseline = cam_info.extrinsics.specTranslation.x * 10  # cm -> mm
+            self.fov = calib.getFov(calib.getStereoLeftCameraId())
+            self.focal = (cam_info.width / 2) / (2. * math.tan(math.radians(self.fov / 2)))
+            self.dispScaleFactor = self.baseline * self.focal
         self.output_queues = []
         for name in self.display:
             cv2.namedWindow(name)

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,2 +1,2 @@
 open3d==0.10.0.0; platform_machine != "armv6l" and platform_machine != "armv7l" and python_version < "3.9"
-ffmpy3==git+git://github.com/VanDavv/ffmpy3.git@master;
+ffmpy3==0.2.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ requests==2.24.0
 argcomplete==1.12.1
 blobconverter==0.0.10
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/
-depthai==2.5.0.0.dev+8bfea2ee12ecd902f2ec8e6bd70356a8dad29ecc
+depthai==2.5.0.0.dev+3078a293ce21430be5de44b0bfda4c3b898a657d
 pytube==10.8.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ requests==2.24.0
 argcomplete==1.12.1
 blobconverter==0.0.10
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/
-depthai==2.5.0.0.dev+3078a293ce21430be5de44b0bfda4c3b898a657d
+depthai==2.5.0.0.dev+8bfea2ee12ecd902f2ec8e6bd70356a8dad29ecc
 pytube==10.8.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,6 @@ opencv-contrib-python==4.4.0.46; platform_machine == "aarch64" or platform_machi
 requests==2.24.0
 argcomplete==1.12.1
 blobconverter==0.0.10
-depthai==2.5.0.0
+--extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/
+depthai==2.5.0.0.dev+8bfea2ee12ecd902f2ec8e6bd70356a8dad29ecc
 pytube==10.8.5


### PR DESCRIPTION
With this PR:
- new sliders were added below depth, disparity and disparity_color previews. They can adjust disparity confidence threshold, bilateral sigma and left right check threshold. Trackbars are in sync, so if we update e.g. the confidence on one slider, other will get updated too
- on the same previews, a new box was added specifying the current median filter used. Users can use a different filter with`m` key. Future dynamic configuration options (like enabling L/R check or subpixel) can be added in this box too
- Improved handling of depth frames (to be the same as is [here](https://gist.github.com/alex-luxonis/b8b3f900ea27e42ded37c70eeb814bb7#file-sub_pixel-py-L98))
- Fixed bug with incorrect handling of `-s / --show` parameter that displayed more frames than was requested by user
- Added mouse click tracker that allows to click on depth / disparity image and see the value at a specific location
- Introduced no-nn mode that allows to disable nn inference and adjusted the created camera nodes by more strictly checking when they're needed so that now `-sub / --subpixel` mode can be accessed with the demo

Demo: (click)
[![demo](http://img.youtube.com/vi/7o6jrLYkd5Q/0.jpg)](http://www.youtube.com/watch?v=7o6jrLYkd5Q "demo")



