### PR TITLE
Fix `-enc color`

### DIFF
--- a/depthai_helpers/managers.py
+++ b/depthai_helpers/managers.py
@@ -725,7 +725,7 @@ class EncodingManager:
         if camera_name == Previews.color.name:
             if not hasattr(self.pm.nodes, 'cam_rgb'):
                 raise RuntimeError("RGB camera not initialized. Call create_color_cam(res, fps) first!")
-            enc_resolution = (self.pm.nodes.cam_rgb.getResolutionWidth(), self.pm.nodes.pm.cam_rgb.getResolutionHeight())
+            enc_resolution = (self.pm.nodes.cam_rgb.getResolutionWidth(), self.pm.nodes.cam_rgb.getResolutionHeight())
             enc_profile = dai.VideoEncoderProperties.Profile.H265_MAIN
             enc_in = self.pm.nodes.cam_rgb.video
 

--- a/depthai_helpers/managers.py
+++ b/depthai_helpers/managers.py
@@ -725,7 +725,7 @@ class EncodingManager:
         if camera_name == Previews.color.name:
             if not hasattr(self.pm.nodes, 'cam_rgb'):
                 raise RuntimeError("RGB camera not initialized. Call create_color_cam(res, fps) first!")
-            enc_resolution = (self.pm.nodes.cam_rgb.getResolutionWidth(), self.pm.nodes.cam_rgb.getResolutionHeight())
+            enc_resolution = (self.pm.nodes.cam_rgb.getVideoWidth(), self.pm.nodes.cam_rgb.getVideoHeight())
             enc_profile = dai.VideoEncoderProperties.Profile.H265_MAIN
             enc_in = self.pm.nodes.cam_rgb.video
 


### PR DESCRIPTION
1. Fix a typo preventing `-enc color` to work:
`"AttributeError: 'types.SimpleNamespace' object has no attribute 'pm'"`

2. Fix `-enc color -rgbr 3040`, use video output resolution, not camera's, was crashing with:
`RuntimeError: , LRT: 'VideoEncoder(9) - VideoEncoder out of resources.'`
(as `video` is cropped from 4056x3040 to 3840x2160 by default)

Still, `python3 depthai_demo.py -enc color -rgbr 3040` crashes now with:
`RuntimeError: , LRT: 'ColorCamera(4) - Out of memory while creating pool for 'still' frames. Number of frames: 4 each with size: 18385920B'`
But works disabling some other resources, like: `python3 depthai_demo.py -enc color -rgbr 3040 -dd`
We'll need to reduce the pool size for `still`/other outputs in FW, and/or make it configurable.
