### PR TITLE
Improve PoE performance by introducing MJPEG encoding for streams

### DIFF
--- a/depthai_helpers/arg_manager.py
+++ b/depthai_helpers/arg_manager.py
@@ -58,8 +58,6 @@ def parse_args():
     parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument('-cam', '--camera', choices=[Previews.left.name, Previews.right.name, Previews.color.name], default=Previews.color.name, help="Use one of DepthAI cameras for inference (conflicts with -vid)")
     parser.add_argument('-vid', '--video', type=str, help="Path to video file (or YouTube link) to be used for inference (conflicts with -cam)")
-    parser.add_argument('-hq', '--high_quality', action="store_true", default=False,
-                        help="Low quality visualization - uses resized frames")
     parser.add_argument('-dd', '--disable_depth', action="store_true", help="Disable depth information")
     parser.add_argument('-dnn', '--disable_neural_network', action="store_true", help="Disable neural network inference")
     parser.add_argument('-cnnp', '--cnn_path', type=Path, help="Path to cnn model directory to be run")
@@ -89,8 +87,11 @@ def parse_args():
                         help="Enable stereo 'Subpixel' feature.")
     parser.add_argument("-ff", "--full_fov_nn", default=False, action="store_true",
                         help="Full RGB FOV for NN, not keeping the aspect ratio")
-    parser.add_argument("-scale", "--scale", default=1.0, type=float,
-                        help="Scale factor for the output window. Default: %(default)s")
+    parser.add_argument('-scale', '--scale', type=_coma_separated(default=0.5, cast=float), nargs="+", default=[("color", 0.37)],
+                        help="Define which preview windows to scale (grow/shrink). If scale_factor is not provided, it will default to 0.5 \n"
+                             "Format: preview_name or preview_name,scale_factor \n"
+                             "Example: -scale color \n"
+                             "Example: -scale color,0.7 right,2 left,2")
     parser.add_argument("-cm", "--color_map", default="JET", choices=color_maps, help="Change color map used to apply colors to depth/disparity frames. Default: %(default)s")
     parser.add_argument("-maxd", "--max_depth", default=10000, type=int,
                         help="Maximum depth distance for spatial coordinates in mm. Default: %(default)s")
@@ -115,6 +116,7 @@ def parse_args():
                         help="Count and display the number of specified objects on the frame. You can enter either the name of the object or its label id (number).")
     parser.add_argument("-dev", "--device_id", type=str,
                         help="DepthAI MX id of the device to connect to. Use the word 'list' to show all devices and exit.")
+    parser.add_argument('-lowb', '--low_bandwidth', action="store_true", help="Enable low bandwidth mode that uses encoding for data transfer to limit it's size and increase throughput")
     parser.add_argument('-usbs', '--usb_speed', type=str, default="usb3", choices=["usb2", "usb3"], help="Force USB communication speed. Default: %(default)s")
     parser.add_argument('-enc', '--encode', type=_coma_separated(default=30.0, cast=float), nargs="+", default=[],
                         help="Define which cameras to encode (record) \n"


### PR DESCRIPTION
This PR introduces performance improvements by using MJPEG encoding before sending the frames over XLink and then decoding them on the host using OpenCV `imdecode` method.
Due to the current encoder limitations, not all of the preview streams have the encoding enabled:
- :x: `nn_input` (the `passthrough` output from the nn)
- :heavy_check_mark: `color`
- :heavy_check_mark: `left`
- :heavy_check_mark: `right`
- :heavy_check_mark: `rectified_left`
- :heavy_check_mark: `rectified_right`
- :x: `depth_raw`
- :x: `depth`
- :heavy_check_mark: `disparity`
- :heavy_check_mark: `disparity_color`

One important change that had to be introduced is that now the `color` stream is taken from ColorCamera `video` output instead of `preview` (since only `video` output can be MJPEG encoded at the moment). Using this output, the preview window is not cropped and scaled to meet the nn input size, being full FOV instead - but we wanted to introduce this feature anyway in https://github.com/luxonis/depthai/pull/422. Issues reported in that PR will probably affect this PR also, but I think we can merge this PR and address them afterward, just so the demo is usable with PoE devices. CC @Luxonis-Brandon 

Performance on a single stream can reach up to 28 FPS over ethernet (tested on `-s left`)
![image](https://user-images.githubusercontent.com/5244214/127553319-8719438a-1289-4ade-9d66-dd94a8374ea1.png)
The more streams we request, the slower they will perform. At most, we can request up to 4 encoded streams, at which the performance is 10-12 FPS over Ethernet (tested on `-s left right color disparity disparity_color`)
![image](https://user-images.githubusercontent.com/5244214/127553512-65641130-7e6a-4a6f-8ee6-9fa1eaf60cee.png)
Since `disparity_color` and `depth` are in fact the transformed versions of `disparity` and `depth_raw` respectively, they do not require a dedicated encoder and therefore can be used without increasing the resources usage on device - so running `-s disparity disparity_color` will use the same amount of resources as `-s disparity`, as all transformations are performed on host
