### PR TITLE
Add demo tweaks

### DIFF
--- a/depthai_demo.py
+++ b/depthai_demo.py
@@ -278,9 +278,8 @@ with dai.Device(pm.p.getOpenVINOVersion(), device_info, usb2Mode=conf.args.usb_s
                             "fontScale": 0.4,
                             "thickness": 1
                         }
-                        text_w = cv2.getTextSize(text, **text_config)[0][0]
-                        cv2.rectangle(frame, (0, h - 30), (text_w + 20, h), (255, 255, 255), cv2.FILLED)
-                        cv2.putText(frame, text, (10, h - 10), color=fps.fps_color, **text_config)
+                        cv2.putText(frame, text, (10, h - 10), fps.fps_type, 0.5, fps.fps_bg_color, 4, fps.fps_line_type)
+                        cv2.putText(frame, text, (10, h - 10), fps.fps_type, 0.5, fps.fps_color, 1, fps.fps_line_type)
                         return_frame = callbacks.on_show_frame(frame, name)
                         return return_frame if return_frame is not None else frame
                 pv.show_frames(callback=show_frames_callback)

--- a/depthai_demo.py
+++ b/depthai_demo.py
@@ -29,7 +29,6 @@ conf = ConfigManager(parse_args())
 conf.linuxCheckApplyUsbRules()
 if not conf.useCamera and str(conf.args.video).startswith('https'):
     conf.downloadYTVideo()
-conf.adjustPreviewToOptions()
 
 callbacks = load_module(conf.args.callback)
 rgb_res = conf.getRgbResolution()
@@ -132,6 +131,7 @@ if conf.useNN:
 # Pipeline is defined, now we can connect to the device
 with dai.Device(pm.p.getOpenVINOVersion(), device_info, usb2Mode=conf.args.usb_speed == "usb2") as device:
     conf.adjustParamsToDevice(device)
+    conf.adjustPreviewToOptions()
     if conf.lowBandwidth:
         pm.enableLowBandwidth()
     cap = cv2.VideoCapture(conf.args.video) if not conf.useCamera else None

--- a/depthai_demo.py
+++ b/depthai_demo.py
@@ -138,7 +138,7 @@ with dai.Device(pm.p.getOpenVINOVersion(), device_info, usb2Mode=conf.args.usb_s
     fps = FPSHandler() if conf.useCamera else FPSHandler(cap)
 
     if conf.useCamera or conf.args.sync:
-        pv = PreviewManager(fps, display=conf.args.show, colorMap=conf.getColorMap(), dispMultiplier=dispMultiplier, mouseTracker=True, lowBandwidth=conf.lowBandwidth)
+        pv = PreviewManager(fps, display=conf.args.show, colorMap=conf.getColorMap(), dispMultiplier=dispMultiplier, mouseTracker=True, lowBandwidth=conf.lowBandwidth, scale=conf.args.scale)
 
         if conf.leftCameraEnabled:
             pm.create_left_cam(mono_res, conf.args.mono_fps, xout=Previews.left.name in conf.args.show)
@@ -283,7 +283,7 @@ with dai.Device(pm.p.getOpenVINOVersion(), device_info, usb2Mode=conf.args.usb_s
                         cv2.putText(frame, text, (10, h - 10), color=fps.fps_color, **text_config)
                         return_frame = callbacks.on_show_frame(frame, name)
                         return return_frame if return_frame is not None else frame
-                pv.show_frames(scale=conf.args.scale, callback=show_frames_callback)
+                pv.show_frames(callback=show_frames_callback)
             else:
                 if conf.useNN:
                     nn_manager.draw(host_frame, nn_data)

--- a/depthai_helpers/config_manager.py
+++ b/depthai_helpers/config_manager.py
@@ -202,8 +202,11 @@ class ConfigManager:
             self.args.show.append("left")
         if self.args.camera == "right" and "right" not in self.args.show:
             self.args.show.append("right")
-        if self.useDepth and "depth" not in self.args.show:
-            self.args.show.append("depth")
+        if self.useDepth:
+            if self.lowBandwidth and "disparity_color" not in self.args.show:
+                self.args.show.append("disparity_color")
+            elif not self.lowBandwidth and "depth" not in self.args.show:
+                self.args.show.append("depth")
 
     def adjustParamsToDevice(self, device):
         device_info = device.getDeviceInfo()


### PR DESCRIPTION
This PR addresses improvements ideas from #433.
With this PR:
- RGB preview image is now scaled before any overlay is applied (reported [here](https://github.com/luxonis/depthai/pull/433#issuecomment-890573026))
- Applied text printing improvements (reported [here](https://github.com/luxonis/depthai/pull/433#issuecomment-890580600))
  ![image](https://user-images.githubusercontent.com/5244214/127856259-145ab19e-c550-4740-8f44-5433d1a3f0f1.png)
- If low bandwidth mode is detected (PoE usecase), it will use `disparity_color` stream by default instead of `depth`, because the latter one is not yet encodable with MJPEG
