### PR TITLE
Fix OpenPose nn

### DIFF
--- a/depthai_helpers/utils.py
+++ b/depthai_helpers/utils.py
@@ -26,11 +26,11 @@ def to_tensor_result(packet):
     data = {}
     for tensor in packet.getRaw().tensors:
         if tensor.dataType == dai.TensorInfo.DataType.INT:
-            data[tensor.name] = np.array(packet.getLayerInt32(tensor.name)).reshape(tensor.dims[::-1])
+            data[tensor.name] = np.array(packet.getLayerInt32(tensor.name)).reshape(tensor.dims)
         elif tensor.dataType == dai.TensorInfo.DataType.FP16:
-            data[tensor.name] = np.array(packet.getLayerFp16(tensor.name)).reshape(tensor.dims[::-1])
+            data[tensor.name] = np.array(packet.getLayerFp16(tensor.name)).reshape(tensor.dims)
         elif tensor.dataType == dai.TensorInfo.DataType.I8:
-            data[tensor.name] = np.array(packet.getLayerUInt8(tensor.name)).reshape(tensor.dims[::-1])
+            data[tensor.name] = np.array(packet.getLayerUInt8(tensor.name)).reshape(tensor.dims)
         else:
             print("Unsupported tensor layer type: {}".format(tensor.dataType))
     return data

--- a/resources/nn/deeplabv3p_person/handler.py
+++ b/resources/nn/deeplabv3p_person/handler.py
@@ -19,4 +19,4 @@ def draw(nn_manager, data, frames):
 
     for name, frame in frames:
         if name == nn_manager.source:
-            cv2.addWeighted(frame, 1, data, 0.2, 0, frame)
+            cv2.addWeighted(frame, 1, cv2.resize(data, frame.shape[0:2][::-1]), 0.2, 0, frame)

--- a/resources/nn/deeplabv3p_person/handler.py
+++ b/resources/nn/deeplabv3p_person/handler.py
@@ -1,6 +1,7 @@
 import cv2
 import numpy as np
 
+from depthai_helpers.managers import Previews
 from depthai_helpers.utils import to_tensor_result
 
 
@@ -18,5 +19,5 @@ def draw(nn_manager, data, frames):
         return
 
     for name, frame in frames:
-        if name == nn_manager.source:
+        if name in (Previews.color.name, Previews.nn_input.name):
             cv2.addWeighted(frame, 1, cv2.resize(data, frame.shape[0:2][::-1]), 0.2, 0, frame)

--- a/resources/nn/openpose2/handler.py
+++ b/resources/nn/openpose2/handler.py
@@ -164,7 +164,7 @@ def draw(nn_manager, keypoints_limbs, frames):
         def scale(point):
             return int(point[0] * factor_w), int(point[1] * factor_h)
 
-        if name == nn_manager.source and len(keypoints_limbs) == 3:
+        if len(keypoints_limbs) == 3:
             detected_keypoints = keypoints_limbs[0]
             personwiseKeypoints = keypoints_limbs[1]
             keypoints_list = keypoints_limbs[2]

--- a/resources/nn/openpose2/handler.py
+++ b/resources/nn/openpose2/handler.py
@@ -158,6 +158,12 @@ def decode(nn_manager, packet):
 
 def draw(nn_manager, keypoints_limbs, frames):
     for name, frame in frames:
+        factor_w = frame.shape[1] / nn_manager.input_size[0]
+        factor_h = frame.shape[0] / nn_manager.input_size[1]
+
+        def scale(point):
+            return int(point[0] * factor_w), int(point[1] * factor_h)
+
         if name == nn_manager.source and len(keypoints_limbs) == 3:
             detected_keypoints = keypoints_limbs[0]
             personwiseKeypoints = keypoints_limbs[1]
@@ -165,7 +171,7 @@ def draw(nn_manager, keypoints_limbs, frames):
 
             for i in range(nPoints):
                 for j in range(len(detected_keypoints[i])):
-                    cv2.circle(frame, detected_keypoints[i][j][0:2], 5, colors[i], -1, cv2.LINE_AA)
+                    cv2.circle(frame, scale(detected_keypoints[i][j][0:2]), 5, colors[i], -1, cv2.LINE_AA)
             for i in range(17):
                 for n in range(len(personwiseKeypoints)):
                     index = personwiseKeypoints[n][np.array(POSE_PAIRS[i])]
@@ -173,5 +179,5 @@ def draw(nn_manager, keypoints_limbs, frames):
                         continue
                     B = np.int32(keypoints_list[index.astype(int), 0])
                     A = np.int32(keypoints_list[index.astype(int), 1])
-                    cv2.line(frame, (B[0], A[0]), (B[1], A[1]), colors[i], 3, cv2.LINE_AA)
+                    cv2.line(frame, scale((B[0], A[0])), scale((B[1], A[1])), colors[i], 3, cv2.LINE_AA)
 


### PR DESCRIPTION
This PR fixes the` openpose2` neural network, it crashed on main with

```
Traceback (most recent call last):
  File "./depthai_demo.py", line 264, in <module>
    nn_data = nn_manager.decode(in_nn)
  File "/Users/leeroy/depthai/depthai_helpers/managers.py", line 469, in decode
    return self.handler.decode(self, in_nn)
  File "/Users/leeroy/depthai/resources/nn/openpose2/handler.py", line 152, in decode
    valid_pairs, invalid_pairs = getValidPairs(outputs, w, h, detected_keypoints)
  File "/Users/leeroy/depthai/resources/nn/openpose2/handler.py", line 46, in getValidPairs
    pafA = outputs[0, mapIdx[k][0], :, :]
IndexError: index 47 is out of bounds for axis 1 with size 46
```

The source of this issue was the `[::-1]` transformation of tensor dimensions. The bug that it resolved was fixed in the latest API release and after the update, the transformation started to bring the opposite effect (yielded incorrect tensor dims)

Also, since we're using full FOV now for preview, had to adjust `handler.py` for openpose to scale the NN results accordingly