### PR TITLE
Fix OpenPose & Deeplab nn mapping

### DIFF
--- a/resources/nn/deeplabv3p_person/handler.py
+++ b/resources/nn/deeplabv3p_person/handler.py
@@ -20,4 +20,10 @@ def draw(nn_manager, data, frames):
 
     for name, frame in frames:
         if name in (Previews.color.name, Previews.nn_input.name):
-            cv2.addWeighted(frame, 1, cv2.resize(data, frame.shape[0:2][::-1]), 0.2, 0, frame)
+            scale_factor = frame.shape[0] / nn_manager.input_size[1]
+            resize_w = int(nn_manager.input_size[0] * scale_factor)
+            resized = cv2.resize(data, (resize_w, frame.shape[0])).astype(data.dtype)
+            offset_w = int(frame.shape[1] - nn_manager.input_size[0] * scale_factor) // 2
+            tail_w = frame.shape[1] - offset_w - resize_w
+            stacked = np.hstack((np.zeros((frame.shape[0], offset_w, 3)).astype(resized.dtype), resized, np.zeros((frame.shape[0], tail_w, 3)).astype(resized.dtype)))
+            cv2.addWeighted(frame, 1, stacked, 0.2, 0, frame)

--- a/resources/nn/openpose2/handler.py
+++ b/resources/nn/openpose2/handler.py
@@ -158,11 +158,11 @@ def decode(nn_manager, packet):
 
 def draw(nn_manager, keypoints_limbs, frames):
     for name, frame in frames:
-        factor_w = frame.shape[1] / nn_manager.input_size[0]
-        factor_h = frame.shape[0] / nn_manager.input_size[1]
+        scale_factor = frame.shape[0] / nn_manager.input_size[1]
+        offset_w = int(frame.shape[1] - nn_manager.input_size[0] * scale_factor) // 2
 
         def scale(point):
-            return int(point[0] * factor_w), int(point[1] * factor_h)
+            return int(point[0] * scale_factor) + offset_w, int(point[1] * scale_factor)
 
         if len(keypoints_limbs) == 3:
             detected_keypoints = keypoints_limbs[0]


### PR DESCRIPTION
This PR fixes the nn overlay issue reported in #435 .
Due to this, both deeplabv3p_person and openpose2 were displaying it's results on larger frames with scaling issue (they were not showing the results correctly)

Now, the openpose2 shows correct output on the color preview (the results are off on the depth preview due to no rgb-depth alignment)
![frame_009_delay-0 04s](https://user-images.githubusercontent.com/5244214/128597005-2c9b6c47-1a77-49fc-a0e5-e01dffd25ad2.gif)

Also, the deeplab network is now correctly presenting it's results too
![Screenshot from 2021-08-07 12-16-19](https://user-images.githubusercontent.com/5244214/128597070-d34ac224-cb56-4724-9baf-eb1e50cdc090.png)
