### PR TITLE
Update blobconverter to 1.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ opencv-python==4.4.0.46; platform_machine == "armv6l" or platform_machine == "ar
 opencv-contrib-python==4.4.0.46; platform_machine == "armv6l" or platform_machine == "armv7l"
 requests==2.24.0
 argcomplete==1.12.1
-blobconverter==0.0.10
+blobconverter==1.0.0
 # --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/
 # depthai==2.5.0.0.dev+568cf1c566056eac5a039ebb9a1fa74436c495b5
 depthai==2.8.0.0


### PR DESCRIPTION
With the `1.0.0` version of the blobconverter, we're using updated API url - blobconverter.luxonis.com.

Versions prior to `1.0.0` stopped working after the website transition, but FWIW they can still be used if we set the URL manually (although I'd recommend to update to latest version)
```diff
import blobconverter
+ blobconverter.set_defaults(url="http://blobconverter.luxonis.com")
```