### PR TITLE
Improve install_requirements.py

### DIFF
--- a/install_requirements.py
+++ b/install_requirements.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-
+import platform
 import subprocess
 import sys
 
@@ -7,6 +7,12 @@ import sys
 in_venv = getattr(sys, "real_prefix", getattr(sys, "base_prefix", sys.prefix)) != sys.prefix
 pip_call = [sys.executable, "-m", "pip"]
 pip_install = pip_call + ["install"]
+
+is_pi = platform.machine().startswith("arm") or platform.machine().startswith("aarch")
+if sys.version_info[0] != 3:
+    raise RuntimeError("Demo script requires Python 3 to run (detected : Python %d)" % sys.version_info[0])
+if is_pi and sys.version_info[1] in (7, 9):
+    print("[WARNING] There are no prebuilt wheels for Python 3.{} for OpenCV, building process on this device may be long and unstable".format(sys.version_info[1]))
 
 if not in_venv:
     pip_install.append("--user")

--- a/install_requirements.py
+++ b/install_requirements.py
@@ -6,6 +6,10 @@ import sys
 # https://stackoverflow.com/a/58026969/5494277
 in_venv = getattr(sys, "real_prefix", getattr(sys, "base_prefix", sys.prefix)) != sys.prefix
 pip_call = [sys.executable, "-m", "pip"]
+try:
+    subprocess.check_call([*pip_call, "--version"])
+except subprocess.CalledProcessError as ex:
+    raise RuntimeError("Issues with \"pip\" package detected! Follow the official instructions to install - https://pip.pypa.io/en/stable/installation/")
 pip_install = pip_call + ["install"]
 
 is_pi = platform.machine().startswith("arm") or platform.machine().startswith("aarch")

--- a/install_requirements.py
+++ b/install_requirements.py
@@ -20,7 +20,7 @@ if not pip_installed:
 
 is_pi = platform.machine().startswith("arm") or platform.machine().startswith("aarch")
 if sys.version_info[0] != 3:
-    raise RuntimeError("Demo script requires Python 3 to run (detected : Python %d)" % sys.version_info[0])
+    raise RuntimeError("Demo script requires Python 3 to run (detected : Python {})".format(sys.version_info[0]))
 if is_pi and sys.version_info[1] in (7, 9):
     print("[WARNING] There are no prebuilt wheels for Python 3.{} for OpenCV, building process on this device may be long and unstable".format(sys.version_info[1]))
 
@@ -35,4 +35,4 @@ subprocess.check_call(pip_install + ["-r", "requirements.txt"])
 try:
     subprocess.check_call(pip_install + ["-r", "requirements-optional.txt"], stderr=subprocess.DEVNULL)
 except subprocess.CalledProcessError as ex:
-    print(f"Optional dependencies were not installed. This is not an error.")
+    print("Optional dependencies were not installed. This is not an error.")

--- a/install_requirements.py
+++ b/install_requirements.py
@@ -20,7 +20,7 @@ if not pip_installed:
 
 is_pi = platform.machine().startswith("arm") or platform.machine().startswith("aarch")
 if sys.version_info[0] != 3:
-    raise RuntimeError("Demo script requires Python 3 to run (detected : Python {})".format(sys.version_info[0]))
+    raise RuntimeError("Demo script requires Python 3 to run (detected: Python {})".format(sys.version_info[0]))
 if is_pi and sys.version_info[1] in (7, 9):
     print("[WARNING] There are no prebuilt wheels for Python 3.{} for OpenCV, building process on this device may be long and unstable".format(sys.version_info[1]))
 

--- a/install_requirements.py
+++ b/install_requirements.py
@@ -6,12 +6,17 @@ import sys
 # https://stackoverflow.com/a/58026969/5494277
 in_venv = getattr(sys, "real_prefix", getattr(sys, "base_prefix", sys.prefix)) != sys.prefix
 pip_call = [sys.executable, "-m", "pip"]
+pip_installed = True
+pip_install = pip_call + ["install"]
+
 try:
     subprocess.check_call([*pip_call, "--version"])
 except subprocess.CalledProcessError as ex:
+    pip_installed = False
+
+if not pip_installed:
     err_str = "Issues with \"pip\" package detected! Follow the official instructions to install - https://pip.pypa.io/en/stable/installation/"
     raise RuntimeError(err_str)
-pip_install = pip_call + ["install"]
 
 is_pi = platform.machine().startswith("arm") or platform.machine().startswith("aarch")
 if sys.version_info[0] != 3:

--- a/install_requirements.py
+++ b/install_requirements.py
@@ -9,7 +9,8 @@ pip_call = [sys.executable, "-m", "pip"]
 try:
     subprocess.check_call([*pip_call, "--version"])
 except subprocess.CalledProcessError as ex:
-    raise RuntimeError("Issues with \"pip\" package detected! Follow the official instructions to install - https://pip.pypa.io/en/stable/installation/")
+    err_str = "Issues with \"pip\" package detected! Follow the official instructions to install - https://pip.pypa.io/en/stable/installation/"
+    raise RuntimeError(err_str)
 pip_install = pip_call + ["install"]
 
 is_pi = platform.machine().startswith("arm") or platform.machine().startswith("aarch")

--- a/install_requirements.py
+++ b/install_requirements.py
@@ -27,12 +27,12 @@ if is_pi and sys.version_info[1] in (7, 9):
 if not in_venv:
     pip_install.append("--user")
 
-subprocess.check_call([*pip_install, "pip", "-U"])
+subprocess.check_call(pip_install + ["pip", "-U"])
 # temporary workaroud for issue between main and develop
-subprocess.check_call([*pip_call, "uninstall", "depthai", "--yes"])
-subprocess.check_call([*pip_install, "-r", "requirements.txt"])
+subprocess.check_call(pip_call + ["uninstall", "depthai", "--yes"])
+subprocess.check_call(pip_install + ["-r", "requirements.txt"])
 
 try:
-    subprocess.check_call([*pip_install, "-r", "requirements-optional.txt"], stderr=subprocess.DEVNULL)
+    subprocess.check_call(pip_install + ["-r", "requirements-optional.txt"], stderr=subprocess.DEVNULL)
 except subprocess.CalledProcessError as ex:
     print(f"Optional dependencies were not installed. This is not an error.")

--- a/install_requirements.py
+++ b/install_requirements.py
@@ -10,7 +10,7 @@ pip_installed = True
 pip_install = pip_call + ["install"]
 
 try:
-    subprocess.check_call([*pip_call, "--version"])
+    subprocess.check_call(pip_call + ["--version"])
 except subprocess.CalledProcessError as ex:
     pip_installed = False
 


### PR DESCRIPTION
This PR introduces 2 improvements to `install_requirements.py` file:
- Throws a warning if user is using RPi and Python 3.7 or 3.9 is detected - there are no prebuilt wheels for OpenCV and installation process can take some time
  ![image](https://user-images.githubusercontent.com/5244214/129042559-621897c3-a71e-42b0-a7e5-bad10d908805.png)
- Throws an error if `pip` package is not installed with a link to install instructions
  ![image](https://user-images.githubusercontent.com/5244214/129042746-046df37a-f83c-4530-9795-f9c80190afda.png)
- Throws an error if script is invoked with Python 2 (sometimes it's the default `python` on old Ubuntu / RPi)
  ![image](https://user-images.githubusercontent.com/5244214/129044324-eb22daf7-c6f9-4856-b539-3098579eaa76.png)
