### PR TITLE
Add an error and solution link when detected M1 chip

### DIFF
--- a/install_requirements.py
+++ b/install_requirements.py
@@ -23,7 +23,7 @@ if sys.version_info[0] != 3:
 if platform.machine() == "arm64" and platform.system() == "Darwin":
     err_str = "There are no prebuilt wheels for M1 processors. Please open the following link for a solution - https://discuss.luxonis.com/d/69-running-depthai-on-apple-m1-based-macs"
     raise RuntimeError(err_str)
-is_pi = platform.machine().startswith("armv") or platform.machine().startswith("aarch")
+is_pi = platform.machine().startswith("armk") or platform.machine().startswith("aarch")
 if is_pi and sys.version_info[1] in (7, 9):
     print("[WARNING] There are no prebuilt wheels for Python 3.{} for OpenCV, building process on this device may be long and unstable".format(sys.version_info[1]))
 

--- a/install_requirements.py
+++ b/install_requirements.py
@@ -23,7 +23,7 @@ if sys.version_info[0] != 3:
 if platform.machine() == "arm64" and platform.system() == "Darwin":
     err_str = "There are no prebuilt wheels for M1 processors. Please open the following link for a solution - https://discuss.luxonis.com/d/69-running-depthai-on-apple-m1-based-macs"
     raise RuntimeError(err_str)
-is_pi = platform.machine().startswith("armk") or platform.machine().startswith("aarch")
+is_pi = platform.machine().startswith("arm") or platform.machine().startswith("aarch")
 if is_pi and sys.version_info[1] in (7, 9):
     print("[WARNING] There are no prebuilt wheels for Python 3.{} for OpenCV, building process on this device may be long and unstable".format(sys.version_info[1]))
 

--- a/install_requirements.py
+++ b/install_requirements.py
@@ -18,9 +18,12 @@ if not pip_installed:
     err_str = "Issues with \"pip\" package detected! Follow the official instructions to install - https://pip.pypa.io/en/stable/installation/"
     raise RuntimeError(err_str)
 
-is_pi = platform.machine().startswith("arm") or platform.machine().startswith("aarch")
 if sys.version_info[0] != 3:
     raise RuntimeError("Demo script requires Python 3 to run (detected: Python {})".format(sys.version_info[0]))
+if platform.machine() == "arm64" and platform.system() == "Darwin":
+    err_str = "There are no prebuilt wheels for M1 processors. Please open the following link for a solution - https://discuss.luxonis.com/d/69-running-depthai-on-apple-m1-based-macs"
+    raise RuntimeError(err_str)
+is_pi = platform.machine().startswith("armv") or platform.machine().startswith("aarch")
 if is_pi and sys.version_info[1] in (7, 9):
     print("[WARNING] There are no prebuilt wheels for Python 3.{} for OpenCV, building process on this device may be long and unstable".format(sys.version_info[1]))
 


### PR DESCRIPTION
This PR introduces a better handling for M1 chips in `install_requirements.py` file. Will throw an error, as we don't have prebuilt binaries anyways, but will also provide a link to discuss thread with a solution

<img width="1382" alt="image" src="https://user-images.githubusercontent.com/5244214/129167777-f537b23e-5195-4520-833a-312500dd36eb.png">

I'll move this check together with #448 into depthai-python installer later