### PR TITLE
Updated version of pytube - so downloading of yt videos works again

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ blobconverter==1.0.0
 # --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/
 # depthai==2.5.0.0.dev+568cf1c566056eac5a039ebb9a1fa74436c495b5
 depthai==2.9.0.0
-pytube==10.8.5
+pytube==11.0.0


### PR DESCRIPTION
In previous version of `pytube` we recieved this error:
```Traceback (most recent call last):
  File "depthai_demo.py", line 31, in <module>
    conf.downloadYTVideo()
  File "/home/erik/Luxonis/depthai/depthai_helpers/config_manager.py", line 194, in downloadYTVideo
    raise RuntimeError("Unable to download YouTube video. Please try again")
RuntimeError: Unable to download YouTube video. Please try again
```

Updating `pytube` version to latest fixed this issue.