### PR TITLE
Fix deeplabv3p_person preview on video

### DIFF
--- a/depthai_helpers/managers.py
+++ b/depthai_helpers/managers.py
@@ -818,7 +818,7 @@ class PipelineManager:
                     self.nodes.xout_rect_right.setStreamName(Previews.rectified_right.name)
                 nn.passthrough.link(self.nodes.xout_rect_right.input)
 
-            if use_depth:
+            if self.nn_manager.nn_family in ("YOLO", "mobilenet") and use_depth:
                 if not hasattr(self.nodes, "xout_depth"):
                     self.nodes.xout_rgb = self.p.createXLinkOut()
                     self.nodes.xout_rgb.setStreamName(Previews.depth.name)

--- a/resources/nn/deeplabv3p_person/handler.py
+++ b/resources/nn/deeplabv3p_person/handler.py
@@ -19,7 +19,7 @@ def draw(nn_manager, data, frames):
         return
 
     for name, frame in frames:
-        if name in (Previews.color.name, Previews.nn_input.name):
+        if name == "color" and nn_manager.source == "color" and not nn_manager.full_fov:
             scale_factor = frame.shape[0] / nn_manager.input_size[1]
             resize_w = int(nn_manager.input_size[0] * scale_factor)
             resized = cv2.resize(data, (resize_w, frame.shape[0])).astype(data.dtype)
@@ -27,3 +27,5 @@ def draw(nn_manager, data, frames):
             tail_w = frame.shape[1] - offset_w - resize_w
             stacked = np.hstack((np.zeros((frame.shape[0], offset_w, 3)).astype(resized.dtype), resized, np.zeros((frame.shape[0], tail_w, 3)).astype(resized.dtype)))
             cv2.addWeighted(frame, 1, stacked, 0.2, 0, frame)
+        elif name in (Previews.color.name, Previews.nn_input.name, "host"):
+            cv2.addWeighted(frame, 1, cv2.resize(data, frame.shape[:2][::-1]), 0.2, 0, frame)


### PR DESCRIPTION
This PR resolves #456 and adds a proper handling both for video and full-fov input.

Can be tested using:
- (without full FOV): `python3 depthai_demo.py -s color nn_input -cnn deeplabv3p_person -dff`
- (with full FOV): `python3 depthai_demo.py -s color nn_input -cnn deeplabv3p_person`
- (on YT video): `python3 depthai_demo.py -vid https://www.youtube.com/watch?v=lFlSUUnzLv0 -cnn deeplabv3p_person --sync`