### PR TITLE
Fix FPS calculation on host

### DIFF
--- a/depthai_helpers/managers.py
+++ b/depthai_helpers/managers.py
@@ -1,3 +1,4 @@
+import collections
 import json
 import math
 import sys
@@ -551,46 +552,43 @@ class FPSHandler:
     fps_line_type = cv2.LINE_AA
 
     def __init__(self, cap=None):
-        self.timestamp = time.monotonic()
+        self.timestamp = None
         self.start = None
         self.framerate = cap.get(cv2.CAP_PROP_FPS) if cap is not None else None
         self.useCamera = cap is None
 
-        self.frame_cnt = 0
+        self.iter_cnt = 0
         self.ticks = {}
-        self.ticks_cnt = {}
 
     def next_iter(self):
         if self.start is None:
             self.start = time.monotonic()
 
-        if not self.useCamera:
+        if not self.useCamera and self.timestamp is not None:
             frame_delay = 1.0 / self.framerate
             delay = (self.timestamp + frame_delay) - time.monotonic()
             if delay > 0:
                 time.sleep(delay)
         self.timestamp = time.monotonic()
-        self.frame_cnt += 1
+        self.iter_cnt += 1
 
     def tick(self, name):
-        if name in self.ticks:
-            self.ticks_cnt[name] += 1
-        else:
-            self.ticks[name] = time.monotonic()
-            self.ticks_cnt[name] = 0
+        if name not in self.ticks:
+            self.ticks[name] = collections.deque(maxlen=10)
+        self.ticks[name].append(time.monotonic())
 
     def tick_fps(self, name):
-        if name in self.ticks:
-            time_diff = time.monotonic() - self.ticks[name]
-            return self.ticks_cnt[name] / time_diff if time_diff != 0 else 0
+        if name in self.ticks and len(self.ticks[name]) > 1:
+            time_diff = self.ticks[name][-1] - self.ticks[name][0]
+            return len(self.ticks[name]) / time_diff if time_diff != 0 else 0
         else:
             return 0
 
     def fps(self):
-        if self.start is None:
+        if self.start is None or self.timestamp is None:
             return 0
         time_diff = self.timestamp - self.start
-        return self.frame_cnt / time_diff if time_diff != 0 else 0
+        return self.iter_cnt / time_diff if time_diff != 0 else 0
 
     def print_status(self):
         print("=== TOTAL FPS ===")

--- a/depthai_helpers/managers.py
+++ b/depthai_helpers/managers.py
@@ -574,7 +574,7 @@ class FPSHandler:
 
     def tick(self, name):
         if name not in self.ticks:
-            self.ticks[name] = collections.deque(maxlen=10)
+            self.ticks[name] = collections.deque(maxlen=100)
         self.ticks[name].append(time.monotonic())
 
     def tick_fps(self, name):

--- a/depthai_helpers/managers.py
+++ b/depthai_helpers/managers.py
@@ -580,7 +580,7 @@ class FPSHandler:
     def tick_fps(self, name):
         if name in self.ticks and len(self.ticks[name]) > 1:
             time_diff = self.ticks[name][-1] - self.ticks[name][0]
-            return len(self.ticks[name]) / time_diff if time_diff != 0 else 0
+            return (len(self.ticks[name]) - 1) / time_diff if time_diff != 0 else 0
         else:
             return 0
 


### PR DESCRIPTION
This PR improves FPS calculations - as suggested by @alex-luxonis, `deque` was used and the average FPS is now more reliable.

Running the same command (`python3 depthai_demo.py`) in this PR printed

```
=== TOTAL FPS ===
[color]: 35.3
[depth_raw]: 33.1
[depth]: 33.1
[nn]: 32.3
```

Whereas on `main`

```
=== TOTAL FPS ===
[color]: 27.9
[depth_raw]: 27.6
[depth]: 27.6
[nn]: 27.9
```