### PR TITLE
Add road-segmentation-adas-0001 handler

### DIFF
--- a/depthai_demo.py
+++ b/depthai_demo.py
@@ -263,7 +263,6 @@ with dai.Device(pm.p.getOpenVINOVersion(), device_info, usb2Mode=conf.args.usb_s
 
                 if not conf.args.sync:
                     host_frame = raw_host_frame
-
                 fps.tick('host')
 
             if nn_out is not None:
@@ -290,10 +289,12 @@ with dai.Device(pm.p.getOpenVINOVersion(), device_info, usb2Mode=conf.args.usb_s
                         return return_frame if return_frame is not None else frame
                 pv.show_frames(callback=show_frames_callback)
             elif host_frame is not None:
+                debug_host_frame = host_frame.copy()
+                cv2.imshow("TEST", debug_host_frame)
                 if conf.useNN:
-                    nn_manager.draw(host_frame, nn_data)
-                fps.draw_fps(host_frame, "host")
-                cv2.imshow("host", host_frame)
+                    nn_manager.draw(debug_host_frame, nn_data)
+                fps.draw_fps(debug_host_frame, "host")
+                cv2.imshow("host", debug_host_frame)
 
             if log_out:
                 logs = log_out.tryGetAll()

--- a/depthai_demo.py
+++ b/depthai_demo.py
@@ -290,7 +290,6 @@ with dai.Device(pm.p.getOpenVINOVersion(), device_info, usb2Mode=conf.args.usb_s
                 pv.show_frames(callback=show_frames_callback)
             elif host_frame is not None:
                 debug_host_frame = host_frame.copy()
-                cv2.imshow("TEST", debug_host_frame)
                 if conf.useNN:
                     nn_manager.draw(debug_host_frame, nn_data)
                 fps.draw_fps(debug_host_frame, "host")

--- a/resources/nn/road-segmentation-adas-0001/handler.py
+++ b/resources/nn/road-segmentation-adas-0001/handler.py
@@ -1,0 +1,33 @@
+import cv2
+import numpy as np
+
+from depthai_helpers.managers import Previews
+from depthai_helpers.utils import to_tensor_result
+
+
+def decode(nn_manager, packet):
+    # [print(f"Layer name: {l.name}, Type: {l.dataType}, Dimensions: {l.dims}") for l in packet.getAllLayers()]
+    # after squeeze the data.shape is 4,512, 896
+    data = np.squeeze(to_tensor_result(packet)["L0317_ReWeight_SoftMax"])
+    class_colors = [[0, 0, 0], [0, 255, 0], [255, 0, 0], [0, 0, 255]]
+    class_colors = np.asarray(class_colors, dtype=np.uint8)
+
+    indices = np.argmax(data, axis=0)
+    output_colors = np.take(class_colors, indices, axis=0)
+    return output_colors
+
+
+def draw(nn_manager, data, frames):
+    if len(data) == 0:
+        return
+    for name, frame in frames:
+        if name == "color" and nn_manager.source == "color" and not nn_manager.full_fov:
+            scale_factor = frame.shape[0] / nn_manager.input_size[1]
+            resize_w = int(nn_manager.input_size[0] * scale_factor)
+            resized = cv2.resize(data, (resize_w, frame.shape[0])).astype(data.dtype)
+            offset_w = int(frame.shape[1] - nn_manager.input_size[0] * scale_factor) // 2
+            tail_w = frame.shape[1] - offset_w - resize_w
+            stacked = np.hstack((np.zeros((frame.shape[0], offset_w, 3)).astype(resized.dtype), resized, np.zeros((frame.shape[0], tail_w, 3)).astype(resized.dtype)))
+            cv2.addWeighted(frame, 1, stacked, 0.2, 0, frame)
+        elif name in (Previews.color.name, Previews.nn_input.name, "host"):
+            cv2.addWeighted(frame, 1, cv2.resize(data, frame.shape[:2][::-1]), 0.2, 0, frame)

--- a/resources/nn/road-segmentation-adas-0001/road-segmentation-adas-0001.json
+++ b/resources/nn/road-segmentation-adas-0001/road-segmentation-adas-0001.json
@@ -1,0 +1,7 @@
+{
+    "nn_config": {
+        "output_format" : "raw",
+        "input_size": "896x512"
+    },
+    "handler": "handler.py"
+}


### PR DESCRIPTION
This PR adds a `road-segmentation-adas-0001` handler to depthai-demo. Thanks to @franva for his pointers in #455 that made this PR easier to implement.

### Demo

![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/5244214/130064359-b9534b08-0783-4c86-979b-08cbcaff9341.gif)

### To reproduce

```
depthai_demo.py -cnn road-segmentation-adas-0001 -vid https://www.youtube.com/watch?v=lCmuKhHVAIg --sync
```

### TODO

- [x] Resolve why the detection overlay is sometimes applied twice