### PR TITLE
Bump depthai version to 2.10.0.0; add xlink chunk size config

### DIFF
--- a/depthai_demo.py
+++ b/depthai_demo.py
@@ -116,6 +116,9 @@ if conf.args.openvino_version:
     openvino_version = getattr(dai.OpenVINO.Version, 'VERSION_' + conf.args.openvino_version)
 pm = PipelineManager(openvino_version)
 
+if conf.args.xlink_chunk_size is not None:
+    pm.set_xlink_chunk_size(conf.args.xlink_chunk_size)
+
 if conf.useNN:
     nn_manager = NNetManager(
         input_size=conf.inputSize,

--- a/depthai_helpers/arg_manager.py
+++ b/depthai_helpers/arg_manager.py
@@ -123,4 +123,5 @@ def parse_args():
                              "Example: -enc left color \n"
                              "Example: -enc color right,10 left,10")
     parser.add_argument('-encout', '--encode_output', type=Path, default=project_root, help="Path to directory where to store encoded files. Default: %(default)s")
+    parser.add_argument('-xls', '--xlink_chunk_size', type=int, default = None, help="Specify XLink chunk size")
     return parser.parse_args()

--- a/depthai_helpers/managers.py
+++ b/depthai_helpers/managers.py
@@ -833,6 +833,9 @@ class PipelineManager:
     def enableLowBandwidth(self):
         self.lowBandwidth = True
 
+    def set_xlink_chunk_size(self, chunk_size):
+        self.p.setXLinkChunkSize(chunk_size)
+
 
 
 class EncodingManager:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ argcomplete==1.12.1
 blobconverter==1.0.0
 # --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/
 # depthai==2.5.0.0.dev+568cf1c566056eac5a039ebb9a1fa74436c495b5
-depthai==2.9.0.0
+depthai==2.10.0.0
 pytube==11.0.0


### PR DESCRIPTION
Use case:
Running as :
```
python3 depthai_demo.py -s left right -monor 400 -monof 118 -dnn -dd --xlink_chunk_size 0
```
instead default chunk size (FW specific, currently 64KB) increases FPS from 100 to 118 for both cameras.