### PR TITLE
Fixed max (normal) disparity to 95 (0..95)

### DIFF
--- a/depthai_helpers/config_manager.py
+++ b/depthai_helpers/config_manager.py
@@ -54,7 +54,7 @@ class ConfigManager:
 
     @property
     def maxDisparity(self):
-        max_disparity = 96
+        max_disparity = 95
         if (self.args.extended_disparity):
             max_disparity *= 2
         if (self.args.subpixel):

--- a/depthai_helpers/managers.py
+++ b/depthai_helpers/managers.py
@@ -161,7 +161,7 @@ class PreviewDecoder:
             raw_frame = cv2.imdecode(packet.getData(), cv2.IMREAD_GRAYSCALE)
         else:
             raw_frame = packet.getFrame()
-        return (raw_frame*(manager.dispMultiplier if manager is not None else 255/96)).astype(np.uint8)
+        return (raw_frame*(manager.dispMultiplier if manager is not None else 255/95)).astype(np.uint8)
 
     @staticmethod
     def disparity_color(disparity, manager=None):
@@ -213,7 +213,7 @@ class MouseClickTracker:
 
 
 class PreviewManager:
-    def __init__(self, fps, display, nn_source, colorMap=cv2.COLORMAP_JET, dispMultiplier=255/96, mouseTracker=False, lowBandwidth=False, scale=None, sync=False):
+    def __init__(self, fps, display, nn_source, colorMap=cv2.COLORMAP_JET, dispMultiplier=255/95, mouseTracker=False, lowBandwidth=False, scale=None, sync=False):
         self.display = display
         self.frames = {}
         self.raw_frames = {}


### PR DESCRIPTION
Also in `config_manager.py` we should remove the helper function `def maxDisparity(self):` and instead use `stereo.getMaxDisparity()`