### PR TITLE
fix: for upsidedown image from oak1

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ python3 install_requirements.py
 
 `python3 depthai_demo.py -vid <path_to_video_or_yt_link>` - CNN inference on video example
 
+`python3 depthai_demo.py -cam_model oak1` - Applies appropriate defaults, ie flips the Camera image Horizontal so that it is correct way up
+
 `python3 depthai_demo.py -cnn person-detection-retail-0013` - Run `person-detection-retail-0013` model from `resources/nn` directory
 
 `python3 depthai_demo.py -cnn tiny-yolo-v3 -sh 8` - Run `tiny-yolo-v3` model from `resources/nn` directory and compile for 8 shaves
@@ -27,7 +29,8 @@ python3 install_requirements.py
 ```
 $ depthai_demo.py --help
 
-usage: depthai_demo.py [-h] [-cam {left,right,color}] [-vid VIDEO] [-hq] [-dd] [-dnn] [-cnnp CNN_PATH] [-cnn CNN_MODEL] [-sh SHAVES]
+usage: depthai_demo.py [-h] [-cam {left,right,color}] [-cam_model {oakd, oak1}] [-vid VIDEO] 
+                       [-hq] [-dd] [-dnn] [-cnnp CNN_PATH] [-cnn CNN_MODEL] [-sh SHAVES]
                        [-cnn_size CNN_INPUT_SIZE] [-rgbr {1080,2160,3040}] [-rgbf RGB_FPS] [-dct DISPARITY_CONFIDENCE_THRESHOLD] [-lrct LRC_THRESHOLD]
                        [-sig SIGMA] [-med {0,3,5,7}] [-lrc] [-ext] [-sub] [-ff] [-scale SCALE]
                        [-cm {AUTUMN,BONE,CIVIDIS,COOL,DEEPGREEN,HOT,HSV,INFERNO,JET,MAGMA,OCEAN,PARULA,PINK,PLASMA,RAINBOW,SPRING,SUMMER,TURBO,TWILIGHT,TWILIGHT_SHIFTED,VIRIDIS,WINTER}]
@@ -41,6 +44,9 @@ optional arguments:
   -h, --help            show this help message and exit
   -cam {left,right,color}, --camera {left,right,color}
                         Use one of DepthAI cameras for inference (conflicts with -vid)
+  -cam_model {oakd, oak1}, --camera_model {oakd, oak1}
+                        Define what camera is being accessed to enable correct default configurations, ie Oak1 flip horizontal
+
   -vid VIDEO, --video VIDEO
                         Path to video file (or YouTube link) to be used for inference (conflicts with -cam)
   -hq, --high_quality   Low quality visualization - uses resized frames

--- a/depthai_demo.py
+++ b/depthai_demo.py
@@ -154,7 +154,8 @@ with dai.Device(pm.p.getOpenVINOVersion(), device_info, usb2Mode=conf.args.usb_s
                                 )
         if conf.rgbCameraEnabled:
             pm.create_color_cam(nn_manager.input_size if conf.useNN else conf.previewSize, rgb_res, conf.args.rgb_fps,
-                                not conf.args.disable_full_fov_nn, xout=Previews.color.name in conf.args.show  and (conf.getModelSource() != "color" or not conf.args.sync)
+                                not conf.args.disable_full_fov_nn, xout=Previews.color.name in conf.args.show  and (conf.getModelSource() != "color" or not conf.args.sync),
+                                oak1=(conf.args.camera_model=="oak1")
                                 )
 
         if conf.useDepth:

--- a/depthai_helpers/arg_manager.py
+++ b/depthai_helpers/arg_manager.py
@@ -57,6 +57,7 @@ project_root = Path(__file__).parent.parent
 def parse_args():
     parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument('-cam', '--camera', choices=[Previews.left.name, Previews.right.name, Previews.color.name], default=Previews.color.name, help="Use one of DepthAI cameras for inference (conflicts with -vid)")
+    parser.add_argument('-cam_model', '--camera_model', choices=["oakd","oak1"], default="oakd", help="Defines appropriate defaults for DepthAI cameras models oakd or oak1")
     parser.add_argument('-vid', '--video', type=str, help="Path to video file (or YouTube link) to be used for inference (conflicts with -cam)")
     parser.add_argument('-dd', '--disable_depth', action="store_true", help="Disable depth information")
     parser.add_argument('-dnn', '--disable_neural_network', action="store_true", help="Disable neural network inference")

--- a/depthai_helpers/managers.py
+++ b/depthai_helpers/managers.py
@@ -659,9 +659,11 @@ class PipelineManager:
             raise NotImplementedError("Unable to create mjpeg link for encountered node type: {}".format(type(node)))
         videnc.bitstream.link(xout.input)
 
-    def create_color_cam(self, preview_size, res, fps, full_fov, xout=False):
+    def create_color_cam(self, preview_size, res, fps, full_fov, xout=False,oak1=False):
         # Define a source - color camera
         self.nodes.cam_rgb = self.p.createColorCamera()
+        if oak1:
+            self.nodes.cam_rgb.setImageOrientation(dai.CameraImageOrientation.ROTATE_180_DEG)
         self.nodes.cam_rgb.setPreviewSize(*preview_size)
         self.nodes.cam_rgb.setInterleaved(False)
         self.nodes.cam_rgb.setResolution(res)


### PR DESCRIPTION
When using the Oak1 in the `depthai_demo.py` the image is upside down. 

```
 [-cam_model {oakd, oak1}]
```

The following enables a command line argument to allow specifying the model of camera so as to apply appropriate defaults.

See discussion and relevant links https://discuss.luxonis.com/d/311-oak-1-poe-image-image-upside-down-using-depthai-demo-py

and thanks to @alex-luxonis  and Naraka on discord for solution https://discord.com/channels/790680891252932659/799407361986658354/882061206330966117