### PR TITLE
Fix default camera orientation for OAK-1-PoE, was rotated

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ requests==2.24.0
 argcomplete==1.12.1
 blobconverter==1.0.0
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/
-depthai==2.10.0.0.dev+d0a284c58f2a6a2ed26e2f38fd32b911b8885924
+depthai==2.10.0.0.dev+7a0749a61597c086c5fd6e579618ae33accec8df
 # depthai==2.10.0.0
 pytube==11.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ opencv-contrib-python==4.4.0.46; platform_machine == "armv6l" or platform_machin
 requests==2.24.0
 argcomplete==1.12.1
 blobconverter==1.0.0
-# --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/
-# depthai==2.5.0.0.dev+568cf1c566056eac5a039ebb9a1fa74436c495b5
-depthai==2.10.0.0
+--extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/
+depthai==2.10.0.0.dev+d0a284c58f2a6a2ed26e2f38fd32b911b8885924
+# depthai==2.10.0.0
 pytube==11.0.0


### PR DESCRIPTION
The default setting ( `cam_rgb.setImageOrientation(dai.CameraImageOrientation.AUTO)` ) will default now to `ROTATE_180_DEG` (in order to match how the camera module is mounted inside the device).