### PR TITLE
Add -camo / --camera_orientation flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ optional arguments:
   -xls XLINK_CHUNK_SIZE, --xlink_chunk_size XLINK_CHUNK_SIZE
                         Specify XLink chunk size
   -camo CAMERA_ORIENTATION [CAMERA_ORIENTATION ...], --camera_orientation CAMERA_ORIENTATION [CAMERA_ORIENTATION ...]
-                        Define cameras orientation (see depthai.CameraImageOrientation for available choices) 
+                        Define cameras orientation (available: AUTO, NORMAL, HORIZONTAL_MIRROR, VERTICAL_FLIP, ROTATE_180_DEG) 
                         Format: camera_name,camera_orientation 
                         Example: -rot color,ROTATE_180_DEG right,ROTATE_180_DEG left,ROTATE_180_DEG
 ```

--- a/README.md
+++ b/README.md
@@ -27,15 +27,14 @@ python3 install_requirements.py
 ```
 $ depthai_demo.py --help
 
-usage: depthai_demo.py [-h] [-cam {left,right,color}] [-vid VIDEO] [-hq] [-dd] [-dnn] [-cnnp CNN_PATH] [-cnn CNN_MODEL] [-sh SHAVES]
-                       [-cnn_size CNN_INPUT_SIZE] [-rgbr {1080,2160,3040}] [-rgbf RGB_FPS] [-dct DISPARITY_CONFIDENCE_THRESHOLD] [-lrct LRC_THRESHOLD]
-                       [-sig SIGMA] [-med {0,3,5,7}] [-lrc] [-ext] [-sub] [-ff] [-scale SCALE]
+usage: depthai_demo.py [-h] [-cam {left,right,color}] [-vid VIDEO] [-dd] [-dnn] [-cnnp CNN_PATH] [-cnn CNN_MODEL] [-sh SHAVES] [-cnn_size CNN_INPUT_SIZE] [-rgbr {1080,2160,3040}] [-rgbf RGB_FPS]
+                       [-dct DISPARITY_CONFIDENCE_THRESHOLD] [-lrct LRC_THRESHOLD] [-sig SIGMA] [-med {0,3,5,7}] [-lrc] [-ext] [-sub] [-dff] [-scale SCALE [SCALE ...]]
                        [-cm {AUTUMN,BONE,CIVIDIS,COOL,DEEPGREEN,HOT,HSV,INFERNO,JET,MAGMA,OCEAN,PARULA,PINK,PLASMA,RAINBOW,SPRING,SUMMER,TURBO,TWILIGHT,TWILIGHT_SHIFTED,VIRIDIS,WINTER}]
                        [-maxd MAX_DEPTH] [-mind MIN_DEPTH] [-sbb] [-sbb_sf SBB_SCALE_FACTOR]
                        [-s {nn_input,color,left,right,depth,depth_raw,disparity,disparity_color,rectified_left,rectified_right} [{nn_input,color,left,right,depth,depth_raw,disparity,disparity_color,rectified_left,rectified_right} ...]]
-                       [--report {temp,cpu,memory} [{temp,cpu,memory} ...]] [--report_file REPORT_FILE] [-sync] [-monor {400,720,800}] [-monof MONO_FPS]
-                       [-cb CALLBACK] [--openvino_version {2020_1,2020_2,2020_3,2020_4,2021_1,2021_2,2021_3}] [--count COUNT_LABEL] [-dev DEVICE_ID]
-                       [-usbs {usb2,usb3}] [-enc ENCODE [ENCODE ...]] [-encout ENCODE_OUTPUT]
+                       [--report {temp,cpu,memory} [{temp,cpu,memory} ...]] [--report_file REPORT_FILE] [-sync] [-monor {400,720,800}] [-monof MONO_FPS] [-cb CALLBACK]
+                       [--openvino_version {2020_3,2020_4,2021_1,2021_2,2021_3,2021_4}] [--count COUNT_LABEL] [-dev DEVICE_ID] [-lowb] [-usbs {usb2,usb3}] [-enc ENCODE [ENCODE ...]]
+                       [-encout ENCODE_OUTPUT] [-xls XLINK_CHUNK_SIZE] [-camo CAMERA_ORIENTATION [CAMERA_ORIENTATION ...]]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -43,7 +42,6 @@ optional arguments:
                         Use one of DepthAI cameras for inference (conflicts with -vid)
   -vid VIDEO, --video VIDEO
                         Path to video file (or YouTube link) to be used for inference (conflicts with -cam)
-  -hq, --high_quality   Low quality visualization - uses resized frames
   -dd, --disable_depth  Disable depth information
   -dnn, --disable_neural_network
                         Disable neural network inference
@@ -52,7 +50,7 @@ optional arguments:
   -cnn CNN_MODEL, --cnn_model CNN_MODEL
                         Cnn model to run on DepthAI
   -sh SHAVES, --shaves SHAVES
-                        Name of the nn to be run from default depthai repository
+                        Number of MyriadX SHAVEs to use for neural network blob compilation
   -cnn_size CNN_INPUT_SIZE, --cnn_input_size CNN_INPUT_SIZE
                         Neural network input dimensions, in "WxH" format, e.g. "544x320"
   -rgbr {1080,2160,3040}, --rgb_resolution {1080,2160,3040}
@@ -72,9 +70,13 @@ optional arguments:
   -ext, --extended_disparity
                         Enable stereo 'Extended Disparity' feature.
   -sub, --subpixel      Enable stereo 'Subpixel' feature.
-  -dff, --disable_full_fov_nn    Disable full RGB FOV for NN, keeping the nn aspect ratio
-  -scale SCALE, --scale SCALE
-                        Scale factor for the output window. Default: 1.0
+  -dff, --disable_full_fov_nn
+                        Disable full RGB FOV for NN, keeping the nn aspect ratio
+  -scale SCALE [SCALE ...], --scale SCALE [SCALE ...]
+                        Define which preview windows to scale (grow/shrink). If scale_factor is not provided, it will default to 0.5 
+                        Format: preview_name or preview_name,scale_factor 
+                        Example: -scale color 
+                        Example: -scale color,0.7 right,2 left,2
   -cm {AUTUMN,BONE,CIVIDIS,COOL,DEEPGREEN,HOT,HSV,INFERNO,JET,MAGMA,OCEAN,PARULA,PINK,PLASMA,RAINBOW,SPRING,SUMMER,TURBO,TWILIGHT,TWILIGHT_SHIFTED,VIRIDIS,WINTER}, --color_map {AUTUMN,BONE,CIVIDIS,COOL,DEEPGREEN,HOT,HSV,INFERNO,JET,MAGMA,OCEAN,PARULA,PINK,PLASMA,RAINBOW,SPRING,SUMMER,TURBO,TWILIGHT,TWILIGHT_SHIFTED,VIRIDIS,WINTER}
                         Change color map used to apply colors to depth/disparity frames. Default: JET
   -maxd MAX_DEPTH, --max_depth MAX_DEPTH
@@ -97,21 +99,29 @@ optional arguments:
   -monof MONO_FPS, --mono_fps MONO_FPS
                         Mono cam fps: max 60.0 for H:720 or H:800, max 120.0 for H:400. Default: 30.0
   -cb CALLBACK, --callback CALLBACK
-                        Path to callbacks file to be used. Default: <project_root>/callbacks.py
-  --openvino_version {2020_1,2020_2,2020_3,2020_4,2021_1,2021_2,2021_3}
+                        Path to callbacks file to be used. Default: /Users/vandavv/dev/depthai/callbacks.py
+  --openvino_version {2020_3,2020_4,2021_1,2021_2,2021_3,2021_4}
                         Specify which OpenVINO version to use in the pipeline
   --count COUNT_LABEL   Count and display the number of specified objects on the frame. You can enter either the name of the object or its label id (number).
   -dev DEVICE_ID, --device_id DEVICE_ID
                         DepthAI MX id of the device to connect to. Use the word 'list' to show all devices and exit.
+  -lowb, --low_bandwidth
+                        Enable low bandwidth mode that uses encoding for data transfer to limit it's size and increase throughput
   -usbs {usb2,usb3}, --usb_speed {usb2,usb3}
                         Force USB communication speed. Default: usb3
   -enc ENCODE [ENCODE ...], --encode ENCODE [ENCODE ...]
-                        Define which cameras to encode (record)
-                        Format: camera_name or camera_name,enc_fps
-                        Example: -enc left color
+                        Define which cameras to encode (record) 
+                        Format: camera_name or camera_name,enc_fps 
+                        Example: -enc left color 
                         Example: -enc color right,10 left,10
   -encout ENCODE_OUTPUT, --encode_output ENCODE_OUTPUT
-                        Path to directory where to store encoded files. Default: <project_root>
+                        Path to directory where to store encoded files. Default: /Users/vandavv/dev/depthai
+  -xls XLINK_CHUNK_SIZE, --xlink_chunk_size XLINK_CHUNK_SIZE
+                        Specify XLink chunk size
+  -camo CAMERA_ORIENTATION [CAMERA_ORIENTATION ...], --camera_orientation CAMERA_ORIENTATION [CAMERA_ORIENTATION ...]
+                        Define cameras orientation (see depthai.CameraImageOrientation for available choices) 
+                        Format: camera_name,camera_orientation 
+                        Example: -rot color,ROTATE_180_DEG right,ROTATE_180_DEG left,ROTATE_180_DEG
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ optional arguments:
   -monof MONO_FPS, --mono_fps MONO_FPS
                         Mono cam fps: max 60.0 for H:720 or H:800, max 120.0 for H:400. Default: 30.0
   -cb CALLBACK, --callback CALLBACK
-                        Path to callbacks file to be used. Default: /Users/vandavv/dev/depthai/callbacks.py
+                        Path to callbacks file to be used. Default: <project_root>m/callbacks.py
   --openvino_version {2020_3,2020_4,2021_1,2021_2,2021_3,2021_4}
                         Specify which OpenVINO version to use in the pipeline
   --count COUNT_LABEL   Count and display the number of specified objects on the frame. You can enter either the name of the object or its label id (number).
@@ -115,13 +115,13 @@ optional arguments:
                         Example: -enc left color 
                         Example: -enc color right,10 left,10
   -encout ENCODE_OUTPUT, --encode_output ENCODE_OUTPUT
-                        Path to directory where to store encoded files. Default: /Users/vandavv/dev/depthai
+                        Path to directory where to store encoded files. Default: <project_root>
   -xls XLINK_CHUNK_SIZE, --xlink_chunk_size XLINK_CHUNK_SIZE
                         Specify XLink chunk size
   -camo CAMERA_ORIENTATION [CAMERA_ORIENTATION ...], --camera_orientation CAMERA_ORIENTATION [CAMERA_ORIENTATION ...]
                         Define cameras orientation (available: AUTO, NORMAL, HORIZONTAL_MIRROR, VERTICAL_FLIP, ROTATE_180_DEG) 
                         Format: camera_name,camera_orientation 
-                        Example: -rot color,ROTATE_180_DEG right,ROTATE_180_DEG left,ROTATE_180_DEG
+                        Example: -camo color,ROTATE_180_DEG right,ROTATE_180_DEG left,ROTATE_180_DEG
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ optional arguments:
   -monof MONO_FPS, --mono_fps MONO_FPS
                         Mono cam fps: max 60.0 for H:720 or H:800, max 120.0 for H:400. Default: 30.0
   -cb CALLBACK, --callback CALLBACK
-                        Path to callbacks file to be used. Default: <project_root>m/callbacks.py
+                        Path to callbacks file to be used. Default: <project_root>/callbacks.py
   --openvino_version {2020_3,2020_4,2021_1,2021_2,2021_3,2021_4}
                         Specify which OpenVINO version to use in the pipeline
   --count COUNT_LABEL   Count and display the number of specified objects on the frame. You can enter either the name of the object or its label id (number).

--- a/depthai_demo.py
+++ b/depthai_demo.py
@@ -145,16 +145,16 @@ with dai.Device(pm.p.getOpenVINOVersion(), device_info, usb2Mode=conf.args.usb_s
                             scale=conf.args.scale, sync=conf.args.sync)
 
         if conf.leftCameraEnabled:
-            pm.create_left_cam(mono_res, conf.args.mono_fps,
+            pm.create_left_cam(mono_res, conf.args.mono_fps, orientation=conf.args.camera_orientation.get(Previews.left.name),
                                xout=Previews.left.name in conf.args.show and (conf.getModelSource() != "left" or not conf.args.sync)
                                )
         if conf.rightCameraEnabled:
-            pm.create_right_cam(mono_res, conf.args.mono_fps,
+            pm.create_right_cam(mono_res, conf.args.mono_fps, orientation=conf.args.camera_orientation.get(Previews.right.name),
                                 xout=Previews.right.name in conf.args.show and (conf.getModelSource() != "right" or not conf.args.sync)
                                 )
         if conf.rgbCameraEnabled:
-            pm.create_color_cam(nn_manager.input_size if conf.useNN else conf.previewSize, rgb_res, conf.args.rgb_fps,
-                                not conf.args.disable_full_fov_nn, xout=Previews.color.name in conf.args.show  and (conf.getModelSource() != "color" or not conf.args.sync)
+            pm.create_color_cam(nn_manager.input_size if conf.useNN else conf.previewSize, rgb_res, conf.args.rgb_fps, orientation=conf.args.camera_orientation.get(Previews.color.name),
+                                full_fov=not conf.args.disable_full_fov_nn, xout=Previews.color.name in conf.args.show  and (conf.getModelSource() != "color" or not conf.args.sync)
                                 )
 
         if conf.useDepth:

--- a/depthai_helpers/arg_manager.py
+++ b/depthai_helpers/arg_manager.py
@@ -135,7 +135,8 @@ def parse_args():
     parser.add_argument('-encout', '--encode_output', type=Path, default=project_root, help="Path to directory where to store encoded files. Default: %(default)s")
     parser.add_argument('-xls', '--xlink_chunk_size', type=int, default = None, help="Specify XLink chunk size")
     parser.add_argument('-camo', '--camera_orientation', type=_coma_separated(default="AUTO", cast=orientation_cast), nargs="+", default=[],
-                        help="Define cameras orientation (see depthai.CameraImageOrientation for available choices) \n"
+                        help=("Define cameras orientation (available: {}) \n"
                              "Format: camera_name,camera_orientation \n"
-                             "Example: -rot color,ROTATE_180_DEG right,ROTATE_180_DEG left,ROTATE_180_DEG")
+                             "Example: -rot color,ROTATE_180_DEG right,ROTATE_180_DEG left,ROTATE_180_DEG").format(', '.join(orientation_choices))
+                        )
     return parser.parse_args()

--- a/depthai_helpers/arg_manager.py
+++ b/depthai_helpers/arg_manager.py
@@ -54,7 +54,7 @@ orientation_choices = list(filter(lambda var: var[0].isupper(), vars(dai.CameraI
 
 def orientation_cast(arg):
     if not hasattr(dai.CameraImageOrientation, arg):
-        raise argparse.ArgumentTypeError("Invalid camera orientation specified: '{}'. Avalilable: {}".format(arg, orientation_choices))
+        raise argparse.ArgumentTypeError("Invalid camera orientation specified: '{}'. Available: {}".format(arg, orientation_choices))
 
     return getattr(dai.CameraImageOrientation, arg)
 
@@ -137,6 +137,6 @@ def parse_args():
     parser.add_argument('-camo', '--camera_orientation', type=_coma_separated(default="AUTO", cast=orientation_cast), nargs="+", default=[],
                         help=("Define cameras orientation (available: {}) \n"
                              "Format: camera_name,camera_orientation \n"
-                             "Example: -rot color,ROTATE_180_DEG right,ROTATE_180_DEG left,ROTATE_180_DEG").format(', '.join(orientation_choices))
+                             "Example: -camo color,ROTATE_180_DEG right,ROTATE_180_DEG left,ROTATE_180_DEG").format(', '.join(orientation_choices))
                         )
     return parser.parse_args()

--- a/depthai_helpers/arg_manager.py
+++ b/depthai_helpers/arg_manager.py
@@ -36,17 +36,27 @@ def _coma_separated(default, cast=str):
                 "{0} format is invalid. See --help".format(option)
             )
         elif len(option_list) == 1:
-            return option_list[0], default
+            return option_list[0], cast(default)
         else:
             try:
-                float(option_list[1])
+                cast(option_list[1])
             except ValueError:
                 raise argparse.ArgumentTypeError(
-                    "In option: {0} {1} is not a number!".format(option, option_list[1])
+                    "In option: {0} {1} is not in a correct format!".format(option, option_list[1])
                 )
             return option_list[0], cast(option_list[1])
 
     return _fun
+
+
+orientation_choices = list(filter(lambda var: var[0].isupper(), vars(dai.CameraImageOrientation)))
+
+
+def orientation_cast(arg):
+    if not hasattr(dai.CameraImageOrientation, arg):
+        raise argparse.ArgumentTypeError("Invalid camera orientation specified: '{}'. Avalilable: {}".format(arg, orientation_choices))
+
+    return getattr(dai.CameraImageOrientation, arg)
 
 
 openvino_versions = list(map(lambda name: name.replace("VERSION_", ""), filter(lambda name: name.startswith("VERSION_"), vars(dai.OpenVINO.Version))))
@@ -124,4 +134,8 @@ def parse_args():
                              "Example: -enc color right,10 left,10")
     parser.add_argument('-encout', '--encode_output', type=Path, default=project_root, help="Path to directory where to store encoded files. Default: %(default)s")
     parser.add_argument('-xls', '--xlink_chunk_size', type=int, default = None, help="Specify XLink chunk size")
+    parser.add_argument('-camo', '--camera_orientation', type=_coma_separated(default="AUTO", cast=orientation_cast), nargs="+", default=[],
+                        help="Define cameras orientation (see depthai.CameraImageOrientation for available choices) \n"
+                             "Format: camera_name,camera_orientation \n"
+                             "Example: -rot color,ROTATE_180_DEG right,ROTATE_180_DEG left,ROTATE_180_DEG")
     return parser.parse_args()

--- a/depthai_helpers/config_manager.py
+++ b/depthai_helpers/config_manager.py
@@ -36,6 +36,8 @@ class ConfigManager:
             self.args.scale = dict(self.args.scale)
         if not self.useCamera and not self.args.sync:
             print("[WARNING] When using video file as an input, it's highly recommended to run the demo with \"--sync\" flag")
+        if (Previews.left.name in self.args.camera_orientation or Previews.right.name in self.args.camera_orientation) and self.useDepth:
+            print("[WARNING] Changing mono cameras orientation may result in incorrect depth/disparity maps")
 
     @property
     def debug(self):

--- a/depthai_helpers/config_manager.py
+++ b/depthai_helpers/config_manager.py
@@ -29,6 +29,7 @@ class ConfigManager:
     def __init__(self, args):
         self.args = args
         self.args.encode = dict(self.args.encode)
+        self.args.camera_orientation = dict(self.args.camera_orientation)
         if self.args.scale is None:
             self.args.scale = {"color": 0.37 if not self.args.sync else 1}
         else:

--- a/depthai_helpers/managers.py
+++ b/depthai_helpers/managers.py
@@ -659,13 +659,15 @@ class PipelineManager:
             raise NotImplementedError("Unable to create mjpeg link for encountered node type: {}".format(type(node)))
         videnc.bitstream.link(xout.input)
 
-    def create_color_cam(self, preview_size, res, fps, full_fov, xout=False):
+    def create_color_cam(self, preview_size, res, fps, full_fov, orientation: dai.CameraImageOrientation=None, xout=False):
         # Define a source - color camera
         self.nodes.cam_rgb = self.p.createColorCamera()
         self.nodes.cam_rgb.setPreviewSize(*preview_size)
         self.nodes.cam_rgb.setInterleaved(False)
         self.nodes.cam_rgb.setResolution(res)
         self.nodes.cam_rgb.setFps(fps)
+        if orientation is not None:
+            self.nodes.cam_rgb.setImageOrientation(orientation)
         self.nodes.cam_rgb.setPreviewKeepAspectRatio(not full_fov)
         self.nodes.xout_rgb = self.p.createXLinkOut()
         self.nodes.xout_rgb.setStreamName(Previews.color.name)
@@ -750,11 +752,13 @@ class PipelineManager:
         device.getInputQueue("stereo_config").send(self.depthConfig)
 
 
-    def create_left_cam(self, res, fps, xout=False):
+    def create_left_cam(self, res, fps, orientation: dai.CameraImageOrientation=None, xout=False):
         self.nodes.mono_left = self.p.createMonoCamera()
         self.nodes.mono_left.setBoardSocket(dai.CameraBoardSocket.LEFT)
         self.nodes.mono_left.setResolution(res)
         self.nodes.mono_left.setFps(fps)
+        if orientation is not None:
+            self.nodes.mono_left.setImageOrientation(orientation)
 
         self.nodes.xout_left = self.p.createXLinkOut()
         self.nodes.xout_left.setStreamName(Previews.left.name)
@@ -764,11 +768,13 @@ class PipelineManager:
             else:
                 self.nodes.mono_left.out.link(self.nodes.xout_left.input)
 
-    def create_right_cam(self, res, fps, xout=False):
+    def create_right_cam(self, res, fps, orientation: dai.CameraImageOrientation=None, xout=False):
         self.nodes.mono_right = self.p.createMonoCamera()
         self.nodes.mono_right.setBoardSocket(dai.CameraBoardSocket.RIGHT)
         self.nodes.mono_right.setResolution(res)
         self.nodes.mono_right.setFps(fps)
+        if orientation is not None:
+            self.nodes.mono_right.setImageOrientation(orientation)
 
         self.nodes.xout_right = self.p.createXLinkOut()
         self.nodes.xout_right.setStreamName(Previews.right.name)

--- a/tests/guided_manual_test.py
+++ b/tests/guided_manual_test.py
@@ -131,6 +131,12 @@ def test_cameras():
     if not success:
         raise RuntimeError("Preview scaling test failed!")
 
+    show_test_def("Camera orientation", "You should see the both rgb and mono camera previews rotated 180 degrees")
+    subprocess.check_call([*demo_call, "-camo", "left,ROTATE_180_DEG", "right,ROTATE_180_DEG", "color,ROTATE_180_DEG"])
+    success = wait_for_result()
+    if not success:
+        raise RuntimeError("Camera orientation test failed!")
+
     success_frame = get_frame()
     success_frame[:, :, :] = (0, 255, 0)
     cv2.putText(success_frame, "Camera tests passed!", (120, 300), cv2.FONT_HERSHEY_TRIPLEX, 2.0, (0, 0, 0), 10)
@@ -390,7 +396,7 @@ def test_other():
     subprocess.check_call([*demo_call, "-cnn", "vehicle-detection-adas-0002", "-vid", "https://www.youtube.com/watch?v=Y1jTEyb3wiI", "--sync"])
     success = wait_for_result()
     if not success:
-        raise RuntimeError("Reporting test failed!")
+        raise RuntimeError("YouTube video test failed!")
 
     success_frame = get_frame()
     success_frame[:, :, :] = (0, 255, 0)


### PR DESCRIPTION
This PR adds the `-camo / --camera_orientation` flag that allows setting camera orientation property on mono and color cameras.

Usage:

```
  -camo CAMERA_ORIENTATION [CAMERA_ORIENTATION ...], --camera_orientation CAMERA_ORIENTATION [CAMERA_ORIENTATION ...]
                        Define cameras orientation (available: AUTO, NORMAL, HORIZONTAL_MIRROR, VERTICAL_FLIP, ROTATE_180_DEG) 
                        Format: camera_name,camera_orientation 
                        Example: -camo color,ROTATE_180_DEG right,ROTATE_180_DEG left,ROTATE_180_DEG
```