### PR TITLE
Add -bandw / --bandwidth argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ usage: depthai_demo.py [-h] [-cam {left,right,color}] [-vid VIDEO] [-dd] [-dnn] 
                        [-maxd MAX_DEPTH] [-mind MIN_DEPTH] [-sbb] [-sbb_sf SBB_SCALE_FACTOR]
                        [-s {nn_input,color,left,right,depth,depth_raw,disparity,disparity_color,rectified_left,rectified_right} [{nn_input,color,left,right,depth,depth_raw,disparity,disparity_color,rectified_left,rectified_right} ...]]
                        [--report {temp,cpu,memory} [{temp,cpu,memory} ...]] [--report_file REPORT_FILE] [-sync] [-monor {400,720,800}] [-monof MONO_FPS] [-cb CALLBACK]
-                       [--openvino_version {2020_3,2020_4,2021_1,2021_2,2021_3,2021_4}] [--count COUNT_LABEL] [-dev DEVICE_ID] [-lowb] [-usbs {usb2,usb3}] [-enc ENCODE [ENCODE ...]]
-                       [-encout ENCODE_OUTPUT] [-xls XLINK_CHUNK_SIZE] [-camo CAMERA_ORIENTATION [CAMERA_ORIENTATION ...]]
+                       [--openvino_version {2020_3,2020_4,2021_1,2021_2,2021_3,2021_4}] [--count COUNT_LABEL] [-dev DEVICE_ID] [-bandw {auto,low,high}]
+                       [-usbs {usb2,usb3}] [-enc ENCODE [ENCODE ...]] [-encout ENCODE_OUTPUT] [-xls XLINK_CHUNK_SIZE] [-camo CAMERA_ORIENTATION [CAMERA_ORIENTATION ...]]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -105,8 +105,8 @@ optional arguments:
   --count COUNT_LABEL   Count and display the number of specified objects on the frame. You can enter either the name of the object or its label id (number).
   -dev DEVICE_ID, --device_id DEVICE_ID
                         DepthAI MX id of the device to connect to. Use the word 'list' to show all devices and exit.
-  -lowb, --low_bandwidth
-                        Enable low bandwidth mode that uses encoding for data transfer to limit it's size and increase throughput
+  -bandw {auto,low,high}, --bandwidth {auto,low,high}
+                        Force bandwidth mode. Default: auto. Choices: auto, low, high
   -usbs {usb2,usb3}, --usb_speed {usb2,usb3}
                         Force USB communication speed. Default: usb3
   -enc ENCODE [ENCODE ...], --encode ENCODE [ENCODE ...]

--- a/README.md
+++ b/README.md
@@ -106,7 +106,10 @@ optional arguments:
   -dev DEVICE_ID, --device_id DEVICE_ID
                         DepthAI MX id of the device to connect to. Use the word 'list' to show all devices and exit.
   -bandw {auto,low,high}, --bandwidth {auto,low,high}
-                        Force bandwidth mode. Default: auto. Choices: auto, low, high
+                        Force bandwidth mode. 
+                        If set to "high", the output streams will stay uncompressed
+                        If set to "low", the output streams will be MJPEG-encoded
+                        If set to "auto" (default), the optimal bandwidth will be selected based on your connection type and speed
   -usbs {usb2,usb3}, --usb_speed {usb2,usb3}
                         Force USB communication speed. Default: usb3
   -enc ENCODE [ENCODE ...], --encode ENCODE [ENCODE ...]

--- a/depthai_helpers/arg_manager.py
+++ b/depthai_helpers/arg_manager.py
@@ -125,7 +125,7 @@ def parse_args():
                         help="Count and display the number of specified objects on the frame. You can enter either the name of the object or its label id (number).")
     parser.add_argument("-dev", "--device_id", type=str,
                         help="DepthAI MX id of the device to connect to. Use the word 'list' to show all devices and exit.")
-    parser.add_argument('-lowb', '--low_bandwidth', action="store_true", help="Enable low bandwidth mode that uses encoding for data transfer to limit it's size and increase throughput")
+    parser.add_argument('-bandw', '--bandwidth', type=str, default="auto", choices=["auto", "low", "high"], help="Force bandwidth mode. Default: %(default)s. Choices: %(choices)s")
     parser.add_argument('-usbs', '--usb_speed', type=str, default="usb3", choices=["usb2", "usb3"], help="Force USB communication speed. Default: %(default)s")
     parser.add_argument('-enc', '--encode', type=_coma_separated(default=30.0, cast=float), nargs="+", default=[],
                         help="Define which cameras to encode (record) \n"

--- a/depthai_helpers/arg_manager.py
+++ b/depthai_helpers/arg_manager.py
@@ -125,7 +125,10 @@ def parse_args():
                         help="Count and display the number of specified objects on the frame. You can enter either the name of the object or its label id (number).")
     parser.add_argument("-dev", "--device_id", type=str,
                         help="DepthAI MX id of the device to connect to. Use the word 'list' to show all devices and exit.")
-    parser.add_argument('-bandw', '--bandwidth', type=str, default="auto", choices=["auto", "low", "high"], help="Force bandwidth mode. Default: %(default)s. Choices: %(choices)s")
+    parser.add_argument('-bandw', '--bandwidth', type=str, default="auto", choices=["auto", "low", "high"], help="Force bandwidth mode. \n"
+                                                                                                                 "If set to \"high\", the output streams will stay uncompressed\n"
+                                                                                                                 "If set to \"low\", the output streams will be MJPEG-encoded\n"
+                                                                                                                 "If set to \"auto\" (default), the optimal bandwidth will be selected based on your connection type and speed")
     parser.add_argument('-usbs', '--usb_speed', type=str, default="usb3", choices=["usb2", "usb3"], help="Force USB communication speed. Default: %(default)s")
     parser.add_argument('-enc', '--encode', type=_coma_separated(default=30.0, cast=float), nargs="+", default=[],
                         help="Define which cameras to encode (record) \n"

--- a/depthai_helpers/config_manager.py
+++ b/depthai_helpers/config_manager.py
@@ -252,12 +252,15 @@ class ConfigManager:
                 updated_show_arg.append("color")
             self.args.show = updated_show_arg
 
-        if device_info.desc.protocol != dai.XLinkProtocol.X_LINK_USB_VSC:
-            print("Enabling low-bandwidth mode due to connection mode... (protocol: {})".format(device_info.desc.protocol))
-            self.args.low_bandwidth = True
-        elif device.getUsbSpeed() not in [dai.UsbSpeed.SUPER, dai.UsbSpeed.SUPER_PLUS]:
-            print("Enabling low-bandwidth mode due to low USB speed... (speed: {})".format(device.getUsbSpeed()))
-            self.args.low_bandwidth = True
+        if self.args.bandwidth == "auto":
+            if device_info.desc.protocol != dai.XLinkProtocol.X_LINK_USB_VSC:
+                print("Enabling low-bandwidth mode due to connection mode... (protocol: {})".format(device_info.desc.protocol))
+                self.args.bandwidth = "low"
+            elif device.getUsbSpeed() not in [dai.UsbSpeed.SUPER, dai.UsbSpeed.SUPER_PLUS]:
+                print("Enabling low-bandwidth mode due to low USB speed... (speed: {})".format(device.getUsbSpeed()))
+                self.args.bandwidth = "low"
+            else:
+                self.args.bandwidth = "high"
 
 
     def linuxCheckApplyUsbRules(self):
@@ -335,7 +338,7 @@ class ConfigManager:
 
     @property
     def lowBandwidth(self):
-        return self.args.low_bandwidth
+        return self.args.bandwidth == "low"
 
     @property
     def shaves(self):

--- a/tests/guided_manual_test.py
+++ b/tests/guided_manual_test.py
@@ -375,7 +375,7 @@ def test_other():
         raise RuntimeError("Encode all test failed!")
 
     show_test_def("Low bandwidth", "Demo script will run in low-bandwidth mode", "creating MJPEG links")
-    subprocess.check_call([*demo_call, "-lowb"])
+    subprocess.check_call([*demo_call, "--bandwidth", "low"])
     success = wait_for_result()
     if not success:
         raise RuntimeError("Low bandwidth test failed!")


### PR DESCRIPTION
This PR adds the option to set manually the bandwidth.
By default, it's set to `auto` that will resolve the optimal bandwidth automatically but can be also used with `high` or `low` values to force either high or low bandwidth mode respectively