### PR TITLE
Fix encoding at 3040 resolution mode

### DIFF
--- a/depthai_helpers/managers.py
+++ b/depthai_helpers/managers.py
@@ -629,34 +629,38 @@ class PipelineManager:
         for xin in filter(lambda node: isinstance(node, dai.node.XLinkIn), vars(self.nodes).values()):
             device.getInputQueue(xin.getStreamName(), maxSize=1, blocking=False)
 
-    def mjpeg_link(self, node, xout, node_output):
+    def mjpeg_link(self, node, xout, raw_node_output):
         print("Creating MJPEG link for {} node and {} xlink stream...".format(node.getName(), xout.getStreamName()))
         videnc = self.p.createVideoEncoder()
         if isinstance(node, dai.node.ColorCamera) or isinstance(node, dai.node.MonoCamera):
-            videnc.setDefaultProfilePreset(node.getResolutionWidth(), node.getResolutionHeight(), node.getFps(), dai.VideoEncoderProperties.Profile.MJPEG)
-            node_output.link(videnc.input)
+            res_w, res_h, fps = (node.getResolutionWidth(), node.getResolutionHeight(), node.getFps())
         elif isinstance(node, dai.node.StereoDepth):
             camera_node = getattr(self.nodes, 'mono_left', getattr(self.nodes, 'mono_right', None))
             if camera_node is None:
                 raise RuntimeError("Unable to find mono camera node to determine frame size!")
-            videnc.setDefaultProfilePreset(camera_node.getResolutionWidth(), camera_node.getResolutionHeight(), camera_node.getFps(), dai.VideoEncoderProperties.Profile.MJPEG)
-            node_output.link(videnc.input)
+            res_w, res_h, fps = (camera_node.getResolutionWidth(), camera_node.getResolutionHeight(), camera_node.getFps())
         elif isinstance(node, dai.NeuralNetwork):
-            w, h = self.nn_manager.input_size
-            if w % 16 > 0:
-                new_w = w - (w % 16)
-                h = int((new_w / w) * h)
-                w = int(new_w)
-            if h % 2 > 0:
-                h -= 1
-            manip = self.p.createImageManip()
-            manip.initialConfig.setResize(w, h)
-
-            videnc.setDefaultProfilePreset(w, h, 30, dai.VideoEncoderProperties.Profile.MJPEG)
-            node_output.link(manip.inputImage)
-            manip.out.link(videnc.input)
+            res_w, res_h, fps = self.nn_manager.input_size[0], self.nn_manager.input_size[1], 30
         else:
             raise NotImplementedError("Unable to create mjpeg link for encountered node type: {}".format(type(node)))
+
+        if res_w % 16 != 0 or res_h % 2 != 0:
+            if res_w % 16 > 0:
+                new_w = res_w - (res_w % 16)
+                res_h = int((new_w / res_w) * res_h)
+                res_w = int(new_w)
+            if res_h % 2 > 0:
+                res_h -= 1
+
+            manip = self.p.createImageManip()
+            manip.initialConfig.setResize(res_w, res_h)
+            raw_node_output.link(manip.inputImage)
+            node_output = manip.out
+        else:
+            node_output = raw_node_output
+
+        videnc.setDefaultProfilePreset(res_w, res_h, fps, dai.VideoEncoderProperties.Profile.MJPEG)
+        node_output.link(videnc.input)
         videnc.bitstream.link(xout.input)
 
     def create_color_cam(self, preview_size, res, fps, full_fov, orientation: dai.CameraImageOrientation=None, xout=False):

--- a/depthai_helpers/managers.py
+++ b/depthai_helpers/managers.py
@@ -655,8 +655,7 @@ class PipelineManager:
                 size = self.__calc_encodeable_size(node.getStillSize())
                 node.setStillSize(size)
                 videnc.setDefaultProfilePreset(*size, node.getFps(), dai.VideoEncoderProperties.Profile.MJPEG)
-            else:
-                raise NotImplementedError("I made a mistake")
+
             node_output.link(videnc.input)
         elif isinstance(node, dai.node.MonoCamera):
             videnc.setDefaultProfilePreset(node.getResolutionWidth(), node.getResolutionHeight(), node.getFps(), dai.VideoEncoderProperties.Profile.MJPEG)

--- a/tests/guided_manual_test.py
+++ b/tests/guided_manual_test.py
@@ -76,7 +76,7 @@ def wait_for_result():
             return True
         elif key == ord("n"):
             return False
-        if key == 27 or key == ord("q"):  # 27 - ESC
+        if key == 27:  # 27 - ESC
             raise SystemExit(0)
         else:
             continue
@@ -172,12 +172,12 @@ def test_nn_integration():
     if not success:
         raise RuntimeError("Left source cam (without depth) test failed!")
 
-    show_test_def("Full FOV", "You should see color and nn_input (passthough) outputs",
-                  "nn_input should be the same as color but scaled to", "nn input size (without cropping)")
-    subprocess.check_call([*demo_call, "-s", "nn_input", "color", "-ff"])
+    show_test_def("No Full FOV", "You should see color and nn_input (passthough) outputs",
+                  "nn_input should contain cropped and scaled", "color output to nn size")
+    subprocess.check_call([*demo_call, "-s", "nn_input", "color", "-dff"])
     success = wait_for_result()
     if not success:
-        raise RuntimeError("Full FOV test failed!")
+        raise RuntimeError("No Full FOV test failed!")
 
     show_test_def("Spatial bounding boxes", "You should see depth_raw and depth outputs", "with spatial bounding boxes visible")
     subprocess.check_call([*demo_call, "-s", "depth", "depth_raw", "-sbb"])


### PR DESCRIPTION
This PR fixes `-rgbr 3040 -bandw low` use case, where RGB camera is ran at 12 MP mode but the output stream gets encoded.

TODO - we currently use only video output stream, where we could use isp or raw outputs too for different preview options