### PR TITLE
 Update API docs to include classes listing on the top

### DIFF
--- a/depthai_sdk/docs/source/api.rst
+++ b/depthai_sdk/docs/source/api.rst
@@ -1,6 +1,8 @@
 DepthAI SDK API
 ===============
 
+.. include::  modules-list.rst
+
 Managers
 --------
 

--- a/depthai_sdk/docs/source/getting-started.rst
+++ b/depthai_sdk/docs/source/getting-started.rst
@@ -12,31 +12,7 @@ but over time it evolved to become a package containing many convenience methods
 
 Package is mainly made of **managers**, which handle different aspects of development:
 
-.. list-table::
-  :widths: 50 50
-
-  * - :class:`depthai_sdk.managers.PipelineManager`
-    - Helps in setting up processing pipeline
-  * - :class:`depthai_sdk.managers.NNetManager`
-    - Helps in setting up neural networks
-  * - :class:`depthai_sdk.managers.PreviewManager`
-    - Helps in displaying preview from OAK cameras
-  * - :class:`depthai_sdk.managers.EncodingManager`
-    - Helps in creating videos from OAK cameras
-  * - :class:`depthai_sdk.managers.BlobManager`
-    - Helps in downloading neural networks as MyriadX blobs
-
-Together with managers, you can use:
-
-.. list-table::
-  :widths: 50 50
-
-  * - :class:`depthai_sdk.fps`
-    - For FPS calculations
-  * - :class:`depthai_sdk.previews`
-    - For frame handling
-  * - :class:`depthai_sdk.utils`
-    - For various most-common tasks
+.. include::  modules-list.rst
 
 In some places, code is also adjusted for modifications - e.g. you can set up a custom handler file for neural network
 or pass a callback argument to a function to perform additional modifications

--- a/depthai_sdk/docs/source/index.rst
+++ b/depthai_sdk/docs/source/index.rst
@@ -31,5 +31,5 @@ See :ref:`DepthAI SDK API`
    :hidden:
    :caption: Content:
 
-   getting_started.rst
+   getting-started.rst
    api.rst

--- a/depthai_sdk/docs/source/modules-list.rst
+++ b/depthai_sdk/docs/source/modules-list.rst
@@ -1,0 +1,19 @@
+.. list-table::
+  :widths: 50 50
+
+  * - :class:`depthai_sdk.managers.PipelineManager`
+    - Helps in setting up processing pipeline
+  * - :class:`depthai_sdk.managers.NNetManager`
+    - Helps in setting up neural networks
+  * - :class:`depthai_sdk.managers.PreviewManager`
+    - Helps in displaying preview from OAK cameras
+  * - :class:`depthai_sdk.managers.EncodingManager`
+    - Helps in creating videos from OAK cameras
+  * - :class:`depthai_sdk.managers.BlobManager`
+    - Helps in downloading neural networks as MyriadX blobs
+  * - :class:`depthai_sdk.fps`
+    - For FPS calculations
+  * - :class:`depthai_sdk.previews`
+    - For frame handling
+  * - :class:`depthai_sdk.utils`
+    - For various most-common tasks


### PR DESCRIPTION
This PR adds the overview on top of the API page
<img width="727" alt="Screenshot 2021-09-24 at 15 29 25" src="https://user-images.githubusercontent.com/5244214/134682488-5ceb9cfb-40a1-4dc6-bafe-6114dff821e7.png">
