### PR TITLE
Removed an invalid symlink

### DIFF
--- a/resources/nn/openpose
+++ b/resources/nn/openpose
@@ -1,1 +1,0 @@
-human-pose-estimation-0001/


### PR DESCRIPTION
Symlink `resources/nn/openpose` is pointing to a previously removed location `resources/nn/human-pose-estimation-0001/`