### PR TITLE
Bump blobconverter version

### DIFF
--- a/depthai_sdk/requirements.txt
+++ b/depthai_sdk/requirements.txt
@@ -2,6 +2,6 @@ opencv-python==4.5.1.48 ; platform_machine != "aarch64" and platform_machine != 
 opencv-contrib-python==4.5.1.48 ; platform_machine != "aarch64" and platform_machine != "armv6l" and platform_machine != "armv7l"
 opencv-python==4.4.0.46 ; platform_machine == "armv6l" or platform_machine == "armv7l"
 opencv-contrib-python==4.4.0.46 ; platform_machine == "armv6l" or platform_machine == "armv7l"
-blobconverter==1.0.0
+blobconverter==1.2.2
 pytube==11.0.1
 depthai

--- a/depthai_sdk/setup.py
+++ b/depthai_sdk/setup.py
@@ -7,7 +7,7 @@ with open('requirements.txt') as f:
 
 setup(
     name='depthai-sdk',
-    version='1.1.0',
+    version='1.1.1',
     description='This package contains convenience classes and functions that help in most common tasks while using DepthAI API',
     long_description=io.open("README.md", encoding="utf-8").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Merging for now, as it fixes downloading at least some NN models, for example this will work:
```
python3 install_requirements.py
python3 depthai_demo.py -cnn face-detection-retail-0004
```

The default model `mobilenet-ssd` downloading still fails, this is being investigated.