### PR TITLE
Add max ticks support for tickFPS computation

### DIFF
--- a/depthai_sdk/requirements.txt
+++ b/depthai_sdk/requirements.txt
@@ -1,7 +1,5 @@
-opencv-python==4.5.1.48 ; platform_machine != "aarch64" and platform_machine != "armv6l" and platform_machine != "armv7l"
-opencv-contrib-python==4.5.1.48 ; platform_machine != "aarch64" and platform_machine != "armv6l" and platform_machine != "armv7l"
-opencv-python==4.4.0.46 ; platform_machine == "armv6l" or platform_machine == "armv7l"
-opencv-contrib-python==4.4.0.46 ; platform_machine == "armv6l" or platform_machine == "armv7l"
-blobconverter==1.2.2
-pytube==11.0.1
-depthai
+opencv-python>4
+opencv-contrib-python>4
+blobconverter>=1.2.2
+pytube>=11.0.1
+depthai>2

--- a/depthai_sdk/setup.py
+++ b/depthai_sdk/setup.py
@@ -7,7 +7,7 @@ with open('requirements.txt') as f:
 
 setup(
     name='depthai-sdk',
-    version='1.1.1',
+    version='1.1.2',
     description='This package contains convenience classes and functions that help in most common tasks while using DepthAI API',
     long_description=io.open("README.md", encoding="utf-8").read(),
     long_description_content_type="text/markdown",

--- a/depthai_sdk/src/depthai_sdk/fps.py
+++ b/depthai_sdk/src/depthai_sdk/fps.py
@@ -19,8 +19,8 @@ class FPSHandler:
     def __init__(self, cap=None, maxTicks = 100):
         """
         Args:
-            cap (cv2.VideoCapture): handler to the video file object
-            maxTicks (int): maximum queue length in tickFps computation
+            cap (cv2.VideoCapture, Optional): handler to the video file object
+            maxTicks (int, Optional): maximum ticks amount for FPS calculation
         """
         self._timestamp = None
         self._start = None
@@ -31,9 +31,8 @@ class FPSHandler:
         self._ticks = {}
 
         if maxTicks < 2:
-            warnings.warn(f"FPSHandler maxTicks value must be 2 or higher. "
-                          f"It will automatically be set to 2 instead of {maxTicks}")
-            maxTicks = 2
+            raise ValueError(f"Proviced maxTicks value must be 2 or higher (supplied: {maxTicks})")
+
         self._maxTicks = maxTicks
 
     def nextIter(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,7 @@ argcomplete==1.12.1
 -e ./depthai_sdk
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/
 depthai==2.10.0.0.dev+7a0749a61597c086c5fd6e579618ae33accec8df
+opencv-python==4.5.1.48 ; platform_machine != "aarch64" and platform_machine != "armv6l" and platform_machine != "armv7l"
+opencv-contrib-python==4.5.1.48 ; platform_machine != "aarch64" and platform_machine != "armv6l" and platform_machine != "armv7l"
+opencv-python==4.4.0.46 ; platform_machine == "armv6l" or platform_machine == "armv7l"
+opencv-contrib-python==4.4.0.46 ; platform_machine == "armv6l" or platform_machine == "armv7l"


### PR DESCRIPTION
Currently, FPS is calculated as the `time difference` between the first and the last tick in the array divided by the length of the array. Default queue size is set to 100, which is problematic in 2 stage pipelines with slower 2nd NN, as the speed of the faster NN might prevail, resulting in higher FPS estimation of the pipeline.

This PR adds flag `maxTicks = 100` to the FPSHandler `__init__`. When initializing the FPSHandler, a lower value can be provided to reduce the effect of the first NN. Using `maxTicks = 2` should result in real time FPS.