### PR TITLE
Update requirements installer

### DIFF
--- a/depthai_sdk/requirements.txt
+++ b/depthai_sdk/requirements.txt
@@ -1,4 +1,4 @@
-numpy>1.20
+numpy>1.19
 opencv-python>4
 opencv-contrib-python>4
 blobconverter>=1.2.2

--- a/depthai_sdk/requirements.txt
+++ b/depthai_sdk/requirements.txt
@@ -1,3 +1,4 @@
+numpy
 opencv-python>4
 opencv-contrib-python>4
 blobconverter>=1.2.2

--- a/depthai_sdk/requirements.txt
+++ b/depthai_sdk/requirements.txt
@@ -1,4 +1,4 @@
-numpy
+numpy>1.20
 opencv-python>4
 opencv-contrib-python>4
 blobconverter>=1.2.2

--- a/install_requirements.py
+++ b/install_requirements.py
@@ -56,16 +56,17 @@ if thisPlatform == "aarch64":
     opencvInstalledProperly = False
     try:
         subprocess.check_call([sys.executable, "-c", "import numpy, cv2;"])
-        opencvInstalledProperly = False
-    except subprocess.CalledProcessError as ex:
         opencvInstalledProperly = True
+    except subprocess.CalledProcessError as ex:
+        opencvInstalledProperly = False
 
-    from os import environ
-    OPENBLAS_CORE_TYPE = environ.get('OPENBLAS_CORE_TYPE')
-    if not opencvInstalledProperly or OPENBLAS_CORE_TYPE != 'ARMV8':
-        WARNING='\033[1;5;31m'
-        RED='\033[91m'
-        LINE_CL='\033[0m'
-        SUGGESTION='echo "export OPENBLAS_CORETYPE=AMRV8" >> ~/.bashrc && source ~/.bashrc'
-        print(f'{WARNING}WARNING:{LINE_CL} Need to set OPENBLAS_CORE_TYPE environment variable, otherwise opencv will fail with illegal instruction.')
-        print(f'Run: {RED}{SUGGESTION}{LINE_CL}')
+    if not opencvInstalledProperly:
+        from os import environ
+        OPENBLAS_CORE_TYPE = environ.get('OPENBLAS_CORE_TYPE')
+        if OPENBLAS_CORE_TYPE != 'ARMV8':
+            WARNING='\033[1;5;31m'
+            RED='\033[91m'
+            LINE_CL='\033[0m'
+            SUGGESTION='echo "export OPENBLAS_CORETYPE=ARMV8" >> ~/.bashrc && source ~/.bashrc'
+            print(f'{WARNING}WARNING:{LINE_CL} Need to set OPENBLAS_CORE_TYPE environment variable, otherwise opencv will fail with illegal instruction.')
+            print(f'Run: {RED}{SUGGESTION}{LINE_CL}')

--- a/install_requirements.py
+++ b/install_requirements.py
@@ -48,3 +48,24 @@ try:
     subprocess.check_call(pip_package_install + ["-r", "requirements-optional.txt"], stderr=subprocess.DEVNULL)
 except subprocess.CalledProcessError as ex:
     print("Optional dependencies were not installed. This is not an error.")
+
+
+if thisPlatform == "aarch64":
+    # try to import opencv, numpy in a subprocess, since it might fail with illegal instruction
+    # if it was previously installed w/ pip without setting OPENBLAS_CORE_TYPE=ARMV8 env variable
+    opencvInstalledProperly = False
+    try:
+        subprocess.check_call([sys.executable, "-c", "import numpy, cv2;"])
+        opencvInstalledProperly = False
+    except subprocess.CalledProcessError as ex:
+        opencvInstalledProperly = True
+
+    from os import environ
+    OPENBLAS_CORE_TYPE = environ.get('OPENBLAS_CORE_TYPE')
+    if not opencvInstalledProperly or OPENBLAS_CORE_TYPE != 'ARMV8':
+        WARNING='\033[1;5;31m'
+        RED='\033[91m'
+        LINE_CL='\033[0m'
+        SUGGESTION='echo "export OPENBLAS_CORETYPE=AMRV8" >> ~/.bashrc && source ~/.bashrc'
+        print(f'{WARNING}WARNING:{LINE_CL} Need to set OPENBLAS_CORE_TYPE environment variable, otherwise opencv will fail with illegal instruction.')
+        print(f'Run: {RED}{SUGGESTION}{LINE_CL}')

--- a/install_requirements.py
+++ b/install_requirements.py
@@ -3,11 +3,15 @@ import platform
 import subprocess
 import sys
 
+thisPlatform = platform.machine()
+
 # https://stackoverflow.com/a/58026969/5494277
+# Check if in virtual environment
 in_venv = getattr(sys, "real_prefix", getattr(sys, "base_prefix", sys.prefix)) != sys.prefix
 pip_call = [sys.executable, "-m", "pip"]
 pip_installed = True
-pip_install = pip_call + ["install"]
+pip_install = pip_call + ["install", "-U"]
+pip_package_install = pip_install + ["--prefer-binary"]
 
 try:
     subprocess.check_call(pip_call + ["--version"])
@@ -20,23 +24,27 @@ if not pip_installed:
 
 if sys.version_info[0] != 3:
     raise RuntimeError("Demo script requires Python 3 to run (detected: Python {})".format(sys.version_info[0]))
+
 if platform.machine() == "arm64" and platform.system() == "Darwin":
     err_str = "There are no prebuilt wheels for M1 processors. Please open the following link for a solution - https://discuss.luxonis.com/d/69-running-depthai-on-apple-m1-based-macs"
     raise RuntimeError(err_str)
-is_pi = platform.machine().startswith("arm") or platform.machine().startswith("aarch")
-if is_pi and sys.version_info[1] in (7, 9):
+
+is_pi = thisPlatform.startswith("arm")
+prebuiltWheelsPythonVersion = [7,9]
+if is_pi and sys.version_info[1] not in prebuiltWheelsPythonVersion:
     print("[WARNING] There are no prebuilt wheels for Python 3.{} for OpenCV, building process on this device may be long and unstable".format(sys.version_info[1]))
 
 if not in_venv:
     pip_install.append("--user")
+    pip_package_install.append("--user")
 
-subprocess.check_call(pip_call + ["uninstall", "-y", "opencv-python", "opencv-contrib-python"]) # remove old versions of OpenCV
 subprocess.check_call(pip_install + ["pip", "-U"])
+
 # temporary workaroud for issue between main and develop
 subprocess.check_call(pip_call + ["uninstall", "depthai", "--yes"])
-subprocess.check_call(pip_install + ["-r", "requirements.txt"])
+subprocess.check_call(pip_package_install + ["-r", "requirements.txt"])
 
 try:
-    subprocess.check_call(pip_install + ["-r", "requirements-optional.txt"], stderr=subprocess.DEVNULL)
+    subprocess.check_call(pip_package_install + ["-r", "requirements-optional.txt"], stderr=subprocess.DEVNULL)
 except subprocess.CalledProcessError as ex:
     print("Optional dependencies were not installed. This is not an error.")

--- a/install_requirements.py
+++ b/install_requirements.py
@@ -40,7 +40,7 @@ if not in_venv:
 
 subprocess.check_call(pip_install + ["pip", "-U"])
 
-# temporary workaroud for issue between main and develop
+subprocess.check_call(pip_call + ["uninstall", "opencv-python", "opencv-contrib-python", "--yes"])
 subprocess.check_call(pip_call + ["uninstall", "depthai", "--yes"])
 subprocess.check_call(pip_package_install + ["-r", "requirements.txt"])
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,3 @@ argcomplete==1.12.1
 -e ./depthai_sdk
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/
 depthai==2.10.0.0.dev+7a0749a61597c086c5fd6e579618ae33accec8df
-opencv-python==4.5.1.48 ; platform_machine != "aarch64" and platform_machine != "armv6l" and platform_machine != "armv7l"
-opencv-contrib-python==4.5.1.48 ; platform_machine != "aarch64" and platform_machine != "armv6l" and platform_machine != "armv7l"
-opencv-python==4.4.0.46 ; platform_machine == "armv6l" or platform_machine == "armv7l"
-opencv-contrib-python==4.4.0.46 ; platform_machine == "armv6l" or platform_machine == "armv7l"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,9 @@
 requests==2.24.0
 argcomplete==1.12.1
+opencv-python==4.5.1.48 ; platform_machine != "aarch64" and platform_machine != "armv6l" and platform_machine != "armv7l"
+opencv-contrib-python==4.5.1.48 ; platform_machine != "aarch64" and platform_machine != "armv6l" and platform_machine != "armv7l"
+opencv-python==4.4.0.46 ; platform_machine == "armv6l" or platform_machine == "armv7l"
+opencv-contrib-python==4.4.0.46 ; platform_machine == "armv6l" or platform_machine == "armv7l"
 -e ./depthai_sdk
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/
 depthai==2.10.0.0.dev+7a0749a61597c086c5fd6e579618ae33accec8df

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
 requests==2.24.0
 argcomplete==1.12.1
-opencv-python==4.5.1.48 ; platform_machine != "aarch64" and platform_machine != "armv6l" and platform_machine != "armv7l"
-opencv-contrib-python==4.5.1.48 ; platform_machine != "aarch64" and platform_machine != "armv6l" and platform_machine != "armv7l"
+opencv-python==4.5.4.58 ; platform_machine != "aarch64" and platform_machine != "armv6l" and platform_machine != "armv7l" and python_version == "3.10"
+opencv-python==4.5.1.48 ; platform_machine != "aarch64" and platform_machine != "armv6l" and platform_machine != "armv7l" and python_version != "3.10"
+opencv-contrib-python==4.5.4.58 ; platform_machine != "aarch64" and platform_machine != "armv6l" and platform_machine != "armv7l" and python_version == "3.10"
+opencv-contrib-python==4.5.1.48 ; platform_machine != "aarch64" and platform_machine != "armv6l" and platform_machine != "armv7l" and python_version != "3.10"
 opencv-python==4.4.0.46 ; platform_machine == "armv6l" or platform_machine == "armv7l"
 opencv-contrib-python==4.4.0.46 ; platform_machine == "armv6l" or platform_machine == "armv7l"
 -e ./depthai_sdk


### PR DESCRIPTION
Adds `--prefer-binary` to packages, to prefer precompiled wheels over latest source.
Brings improvements from: https://github.com/luxonis/depthai-python/pull/401

Removed dependencies for opencv-python/contrib specific versions, since SDK already contains them, and we don't hard define opencv version in `depthai-python` neither.

Please test on various platforms.

Why blobconverter version is not set to the latest ? Mainly changes from here: https://github.com/luxonis/depthai/pull/510/files
Pushed hotfix here: https://github.com/luxonis/depthai/commit/a46ad95744d8175f1c87bf8cd92c7423a84b8607

Note, there is an issue between opencv-python and opencv-contrib-python using latest wheels, QT5 related, need to look into it.