### PR TITLE
Update blobconverter version to v1.2.6

### DIFF
--- a/depthai_sdk/requirements.txt
+++ b/depthai_sdk/requirements.txt
@@ -1,5 +1,5 @@
 opencv-python>4
 opencv-contrib-python>4
-blobconverter>=1.2.2,<1.2.5
+blobconverter>=1.2.6
 pytube>=11.0.1
 depthai>2


### PR DESCRIPTION
New release available [here](https://github.com/luxonis/blobconverter/releases/tag/v1.2.6).

The verification step can be tested by running

```
truncate -s -400  ~/.cache/blobconverter/mobilenet-ssd_openvino_2021.4_6shave.blob
```
and then launching the demo again