### PR TITLE
Add demo GIF showing GUI usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 This repo contains demo application, which can load different networks, create pipelines, record video, etc.
 
+[![depthai demo](https://user-images.githubusercontent.com/5244214/142426845-82f5f8fd-ad1a-4873-97a5-2b3fcdb0ca2e.gif)](https://www.youtube.com/watch?v=sCZpsFQBffk)
+
+
 __Documentation is available at [https://docs.luxonis.com/](https://docs.luxonis.com/).__
 
 ## Python modules (Dependencies)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 This repo contains demo application, which can load different networks, create pipelines, record video, etc.
 
-[![depthai demo](https://blobconverter.s3.us-west-2.amazonaws.com/final_6196554adf178800b87a30fd_167716.gif)](https://www.youtube.com/watch?v=sCZpsFQBffk)
+<a href="https://www.youtube.com/watch?v=sCZpsFQBffk">
+   <img src="https://blobconverter.s3.us-west-2.amazonaws.com/final_6196554adf178800b87a30fd_167716.gif" alt="depthai_demo"/>
+</a>
+
 
 
 __Documentation is available at [https://docs.luxonis.com/](https://docs.luxonis.com/).__

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repo contains demo application, which can load different networks, create pipelines, record video, etc.
 
-[![depthai demo](https://user-images.githubusercontent.com/5244214/142426845-82f5f8fd-ad1a-4873-97a5-2b3fcdb0ca2e.gif)](https://www.youtube.com/watch?v=sCZpsFQBffk)
+[![depthai demo](https://blobconverter.s3.us-west-2.amazonaws.com/final_6196554adf178800b87a30fd_167716.gif)](https://www.youtube.com/watch?v=sCZpsFQBffk)
 
 
 __Documentation is available at [https://docs.luxonis.com/](https://docs.luxonis.com/).__

--- a/README.md
+++ b/README.md
@@ -2,10 +2,8 @@
 
 This repo contains demo application, which can load different networks, create pipelines, record video, etc.
 
-<a href="https://www.youtube.com/watch?v=sCZpsFQBffk">
-   <img src="https://blobconverter.s3.us-west-2.amazonaws.com/final_6196554adf178800b87a30fd_167716.gif" alt="depthai_demo"  width="200" height="400"/>
-</a>
-
+_Click on the GIF below to see a full example run_
+[![depthai demo](https://user-images.githubusercontent.com/5244214/142426845-82f5f8fd-ad1a-4873-97a5-2b3fcdb0ca2e.gif)](https://www.youtube.com/watch?v=sCZpsFQBffk)
 
 
 __Documentation is available at [https://docs.luxonis.com/](https://docs.luxonis.com/).__

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repo contains demo application, which can load different networks, create pipelines, record video, etc.
 
 <a href="https://www.youtube.com/watch?v=sCZpsFQBffk">
-   <img src="https://blobconverter.s3.us-west-2.amazonaws.com/final_6196554adf178800b87a30fd_167716.gif" alt="depthai_demo"/>
+   <img src="https://blobconverter.s3.us-west-2.amazonaws.com/final_6196554adf178800b87a30fd_167716.gif" alt="depthai_demo"  width="200" height="400"/>
 </a>
 
 


### PR DESCRIPTION
This PR adds a demo GIF with a link to YouTune showing an example demo run

[![depthai demo](https://user-images.githubusercontent.com/5244214/142426845-82f5f8fd-ad1a-4873-97a5-2b3fcdb0ca2e.gif)](https://www.youtube.com/watch?v=sCZpsFQBffk) 

Tried to add a higher-resolution GIF, but GitHub routes all images via https://camo.githubusercontent.com/ (even for external sourced), and if a file exceeds the size limit (10MB) it will raise "Content length exceeded" error and not return an image (404)