### PR TITLE
Add a workaround for GUI blank window on Windows:

### DIFF
--- a/depthai_demo.py
+++ b/depthai_demo.py
@@ -475,6 +475,8 @@ class Demo:
 
 
 if __name__ == "__main__":
+    if platform.system() == 'Windows':
+        os.environ["QT_QUICK_BACKEND"] = "software"
     from gui.main import DemoQtGui
     from PySide6.QtGui import QImage
 


### PR DESCRIPTION
@alex-luxonis , do we intend to merge this?
```
Failed to create vertex shader: Error 0x80070057: The parameter is incorrect.
Failed to build graphics pipeline state
```
(certain systems only?)