### PR TITLE
Fail silently if metrics aggregation fails

### DIFF
--- a/depthai_helpers/metrics.py
+++ b/depthai_helpers/metrics.py
@@ -50,9 +50,12 @@ class MetricManager:
                 "usb": usb
             }
         }
-        self.demo_table.update({
-            f"devices/{mxid}": data
-        })
+        try:
+            self.demo_table.update({
+                f"devices/{mxid}": data
+            })
+        except:
+            pass
 
 if __name__ == "__main__":
     mm = MetricManager()


### PR DESCRIPTION
If a call to gather statistics fails, it shouldn't affect the demo runtime. This PR fixes this case