### PR TITLE
fix reporting for PoE devices

### DIFF
--- a/depthai_helpers/metrics.py
+++ b/depthai_helpers/metrics.py
@@ -22,7 +22,7 @@ class MetricManager:
     def reportDevice(self, device: dai.Device):
         try:
             device_info = device.getDeviceInfo()
-            mxid = device_info.getMxId()
+            mxid = device.getMxId()
         except:
             return
         try:


### PR DESCRIPTION
With this PR, the MXID of PoE devices is resolved correctly in metrics aggregation