### PR TITLE
Allow to specify which render backend to use (-gt / --guiType)

### DIFF
--- a/depthai_demo.py
+++ b/depthai_demo.py
@@ -886,12 +886,15 @@ def runOpenCv():
 
 
 if __name__ == "__main__":
-    is_pi = platform.machine().startswith("arm")
-    use_cv = args.guiType == "cv" or (args.guiType == "auto" and is_pi)
-    try:
-        import PySide6
-    except:
-        use_cv = True
+    use_cv = args.guiType == "cv"
+    if not use_cv:
+        try:
+            import PySide6
+        except:
+            if args.guiType == "qt":
+                raise
+            else:
+                use_cv = True
     if use_cv:
         args.guiType = "cv"
         runOpenCv()

--- a/depthai_helpers/arg_manager.py
+++ b/depthai_helpers/arg_manager.py
@@ -123,7 +123,7 @@ def parseArgs():
                                                                                                                  "If set to \"high\", the output streams will stay uncompressed\n"
                                                                                                                  "If set to \"low\", the output streams will be MJPEG-encoded\n"
                                                                                                                  "If set to \"auto\" (default), the optimal bandwidth will be selected based on your connection type and speed")
-    parser.add_argument('-gt', '--guiType', type=str, default="auto", choices=["auto", "qt", "cv"], help="Specify GUI type of the demo. \"cv\" uses buil-in OpenCV display methods, \"qt\" uses Qt to display interactive GUI. \"auto\" will use OpenCV for Raspberry Pi and Qt for other platforms")
+    parser.add_argument('-gt', '--guiType', type=str, default="auto", choices=["auto", "qt", "cv"], help="Specify GUI type of the demo. \"cv\" uses built-in OpenCV display methods, \"qt\" uses Qt to display interactive GUI. \"auto\" will use OpenCV for Raspberry Pi and Qt for other platforms")
     parser.add_argument('-usbs', '--usbSpeed', type=str, default="usb3", choices=["usb2", "usb3"], help="Force USB communication speed. Default: %(default)s")
     parser.add_argument('-enc', '--encode', type=_comaSeparated(default=30.0, cast=float), nargs="+", default=[],
                         help="Define which cameras to encode (record) \n"


### PR DESCRIPTION
To enable RPi to work with latest demo, until we migrate to Qt5 we will still use the OpenCV render methods to display camera previews.

It will switch to this mode by default on RPi, and can be enforced with `-gt / --guiType` parameter accepting either `qt`, `cv` or `auto`. 