### PR TITLE
Fix installing requirements on Windows: `pyrebase` -> `pyrebase4`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-requests==2.11.1
+requests==2.26.0
+pyrebase4==4.5
 argcomplete==1.12.1
 opencv-python==4.5.4.58 ; platform_machine != "aarch64" and platform_machine != "armv6l" and platform_machine != "armv7l" and python_version == "3.10"
 opencv-python==4.5.1.48 ; platform_machine != "aarch64" and platform_machine != "armv6l" and platform_machine != "armv7l" and python_version != "3.10"
@@ -10,4 +11,3 @@ opencv-contrib-python==4.4.0.46 ; platform_machine == "armv6l" or platform_machi
 PySide6==6.2.0
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/
 depthai==2.13.0.0
-pyrebase==3.0.27


### PR DESCRIPTION
Also upgrades `requests` to latest - fixing vulnerabilities: https://github.com/luxonis/depthai/pull/545

Note: after installing `pyrebase4`, if the package `pyrebase` is somehow uninstalled, `pyrebase4` would stop working, needing to be reinstalled with `--force-reinstall`, or removed first - similar issue as with `opencv-python` and `opencv-contrib-python`. This isn't separately handled yet.