### PR TITLE
fix broken example usages links in SDK docs

### DIFF
--- a/depthai_sdk/docs/source/getting-started.rst
+++ b/depthai_sdk/docs/source/getting-started.rst
@@ -23,9 +23,9 @@ Example usages
 The original "user" of this SDK was the `demo script <https://github.com/luxonis/depthai/blob/main/depthai_demo.py>`__, where you can see how the SDK is used.
 Below, you can find a list of other projects that also use the SDK and are available to use as a reference
 
-* `<https://github.com/luxonis/depthai-experiments/tree/sdk/gen2-human-pose>`__
-* `<https://github.com/luxonis/depthai-experiments/tree/sdk/gen2-road-segmentation>`__
-* `<https://github.com/luxonis/depthai-experiments/tree/sdk/gen2-people-counter>`__
+* `<https://github.com/luxonis/depthai-experiments/tree/master/gen2-human-pose>`__
+* `<https://github.com/luxonis/depthai-experiments/tree/master/gen2-road-segmentation>`__
+* `<https://github.com/luxonis/depthai-experiments/tree/master/gen2-people-counter>`__
 
 Installation
 ------------


### PR DESCRIPTION
This PR fixes links visible below

![image](https://user-images.githubusercontent.com/5244214/143879452-b83f03f6-7658-404d-a9c6-a744874da3e6.png)

