### PR TITLE
Install numpy version based on python version

### DIFF
--- a/depthai_sdk/requirements.txt
+++ b/depthai_sdk/requirements.txt
@@ -1,4 +1,5 @@
-numpy>1.19
+numpy>=1.19; python_version < "3.7"
+numpy>=1.21; python_version >= "3.7"
 opencv-python>4
 opencv-contrib-python>4
 blobconverter>=1.2.6


### PR DESCRIPTION
Numpy `1.19.5` is the latest wheel that supports `python3.6`.