### PR TITLE
use better requirements specification for PyQt5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,6 @@ opencv-python==4.4.0.46 ; platform_machine == "armv6l" or platform_machine == "a
 opencv-contrib-python==4.4.0.46 ; platform_machine == "armv6l" or platform_machine == "armv7l"
 -e ./depthai_sdk
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-depthai-data-local/wheels/
-pyqt5==5.14.2 ; platform_machine != "armv6l" and platform_machine != "armv7l"
+pyqt5>5,<6 ; platform_machine != "armv6l" and platform_machine != "armv7l"
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/
 depthai==2.13.3.0


### PR DESCRIPTION
This PR introduces less strict version specification for PyQt5, requiring just PyQt5 5.x. Resolves #562 