### PR TITLE
disable disparity encoding to prevent OOM issue

### DIFF
--- a/depthai_sdk/src/depthai_sdk/managers/pipeline_manager.py
+++ b/depthai_sdk/src/depthai_sdk/managers/pipeline_manager.py
@@ -290,7 +290,7 @@ class PipelineManager:
         if useDisparity:
             self.nodes.xoutDisparity = self.pipeline.createXLinkOut()
             self.nodes.xoutDisparity.setStreamName(Previews.disparity.name)
-            if self.lowBandwidth:
+            if False:
                 self._mjpegLink(self.nodes.stereo, self.nodes.xoutDisparity, self.nodes.stereo.disparity)
             else:
                 self.nodes.stereo.disparity.link(self.nodes.xoutDisparity.input)

--- a/depthai_sdk/src/depthai_sdk/managers/preview_manager.py
+++ b/depthai_sdk/src/depthai_sdk/managers/preview_manager.py
@@ -13,7 +13,7 @@ class PreviewManager:
     #: dict: Contains name -> frame mapping that can be used to modify specific frames directly
     frames = {}
 
-    def __init__(self, display=[], nnSource=None, colorMap=cv2.COLORMAP_JET, depthConfig=None, dispMultiplier=255/96, mouseTracker=False, lowBandwidth=False, scale=None, sync=False, fpsHandler=None, createWindows=True):
+    def __init__(self, display=[], nnSource=None, colorMap=None, depthConfig=None, dispMultiplier=255/96, mouseTracker=False, lowBandwidth=False, scale=None, sync=False, fpsHandler=None, createWindows=True):
         """
         Args:
             display (list, Optional): List of :obj:`depthai_sdk.Previews` objects representing the streams to display
@@ -30,7 +30,11 @@ class PreviewManager:
         """
         self.sync = sync
         self.nnSource = nnSource
-        self.colorMap = colorMap
+        if colorMap is not None:
+            self.colorMap = colorMap
+        else:
+            self.colorMap = cv2.applyColorMap(np.arange(256, dtype=np.uint8), cv2.COLORMAP_JET)
+            self.colorMap[0] = [0, 0, 0]
         self.lowBandwidth = lowBandwidth
         self.scale = scale
         self.dispMultiplier = dispMultiplier

--- a/depthai_sdk/src/depthai_sdk/previews.py
+++ b/depthai_sdk/src/depthai_sdk/previews.py
@@ -179,7 +179,7 @@ class PreviewDecoder:
         Returns:
             numpy.ndarray: Ready to use OpenCV frame
         """
-        if manager is not None and manager.lowBandwidth:
+        if False:
             rawFrame = cv2.imdecode(packet.getData(), cv2.IMREAD_GRAYSCALE)
         else:
             rawFrame = packet.getFrame()


### PR DESCRIPTION
When `disparity` was requested with low-bandwidth mode, it caused Out Of Memory error due to too many encoders being created. This PR disables `disparity` stream encoding when in low-bandwidth mode, so that 3 video encoders are created at once

Also, fixes default colormap used in preview manager to use an improved one