### PR TITLE
Tweak QT UI colors

### DIFF
--- a/gui/views/AIProperties.qml
+++ b/gui/views/AIProperties.qml
@@ -159,7 +159,7 @@ ListView {
             id: aiAdvancedSwitch
             x: 167
             y: 228
-            text: qsTr("Show advanced options")
+            text: qsTr("<font color=\"white\">Show advanced options</font>")
             font.family: "Courier"
             autoExclusive: false
             transformOrigin: Item.Center
@@ -301,7 +301,7 @@ ListView {
             y: 0
             width: 167
             height: 38
-            text: qsTr("Enabled")
+            text: qsTr("<font color=\"white\">Enabled</font>")
             checked: true
             autoExclusive: false
             font.family: "Courier"

--- a/gui/views/CameraProperties.qml
+++ b/gui/views/CameraProperties.qml
@@ -573,7 +573,7 @@ ListView {
             id: advancedSwitch
             x: 132
             y: 216
-            text: qsTr("Show advanced options")
+            text: qsTr("<font color=\"white\">Show advanced options</font>")
             font.pointSize: 21
             transformOrigin: Item.Center
             autoExclusive: false

--- a/gui/views/DepthProperties.qml
+++ b/gui/views/DepthProperties.qml
@@ -65,7 +65,7 @@ ListView {
             id: switch1
             x: 0
             y: 187
-            text: qsTr("Left Right Check")
+            text: qsTr("<font color=\"white\">Left Right Check</font>")
             transformOrigin: Item.Center
             font.preferShaping: false
             font.kerning: false
@@ -78,11 +78,11 @@ ListView {
 
         Switch {
             id: switch5
-            x: 328
+            x: 275
             y: 0
             width: 167
             height: 38
-            text: qsTr("Enabled")
+            text: qsTr("<font color=\"white\">Enabled</font>")
             autoExclusive: false
             font.family: "Courier"
             checked: true
@@ -99,7 +99,7 @@ ListView {
             id: switch2
             x: 0
             y: 233
-            text: qsTr("Extended Disparity")
+            text: qsTr("<font color=\"white\">Extended Disparity</font>")
             autoExclusive: false
             font.kerning: false
             font.family: "Courier"
@@ -114,7 +114,7 @@ ListView {
             id: switch3
             x: 0
             y: 141
-            text: qsTr("Subpixel")
+            text: qsTr("<font color=\"white\">Subpixel</font>")
             autoExclusive: false
             font.kerning: false
             transformOrigin: Item.Center
@@ -210,7 +210,7 @@ ListView {
 
         Text {
             id: text1
-            x: 44
+            x: 0
             y: 4
             width: 285
             height: 30
@@ -266,11 +266,11 @@ ListView {
 
         Switch {
             id: switch6
-            x: 443
+            x: 400
             y: 0
-            width: 169
+            width: 200
             height: 38
-            text: qsTr("Use Disparity")
+            text: qsTr("<font color=\"white\">Use Disparity</font>")
             autoExclusive: false
             font.family: "Courier"
             font.kerning: false

--- a/gui/views/MiscProperties.qml
+++ b/gui/views/MiscProperties.qml
@@ -36,7 +36,7 @@ ListView {
 
         TextField {
             id: encColorFps
-            x: 110
+            x: 140
             y: 44
             width: 83
             height: 27
@@ -52,9 +52,9 @@ ListView {
             id: encColorSwitch
             x: 8
             y: 44
-            width: 96
+            width: 150
             height: 27
-            text: qsTr("Color")
+            text: qsTr("<font color=\"white\">Color</font>")
             bottomPadding: 5
             onToggled: {
                 appBridge.toggleColorEncoding(encColorSwitch.checked, encColorFps.text)
@@ -64,7 +64,7 @@ ListView {
         TextField {
             enabled: depthEnabled
             id: encLeftFps
-            x: 110
+            x: 140
             y: 77
             width: 83
             height: 27
@@ -81,9 +81,9 @@ ListView {
             id: encLeftSwitch
             x: 8
             y: 77
-            width: 96
+            width: 150
             height: 27
-            text: qsTr("Left")
+            text: qsTr("<font color=\"white\">Left</font>")
             bottomPadding: 5
             onToggled: {
                 appBridge.toggleLeftEncoding(encLeftSwitch.checked, encLeftFps.text)
@@ -93,7 +93,7 @@ ListView {
         TextField {
             enabled: depthEnabled
             id: encRightFps
-            x: 110
+            x: 140
             y: 110
             width: 83
             height: 27
@@ -110,9 +110,9 @@ ListView {
             id: encRightSwitch
             x: 8
             y: 110
-            width: 96
+            width: 150
             height: 27
-            text: qsTr("Right")
+            text: qsTr("<font color=\"white\">Right</font>")
             bottomPadding: 5
             onToggled: {
                 appBridge.toggleRightEncoding(encLeftSwitch.checked, encLeftFps.text)
@@ -139,7 +139,7 @@ ListView {
             y: 239
             width: 185
             height: 27
-            text: qsTr("Temperature")
+            text: qsTr("<font color=\"white\">Temperature</font>")
             bottomPadding: 5
             onToggled: {
                 appBridge.selectReportingOptions(tempSwitch.checked, cpuSwitch.checked, memSwitch.checked)
@@ -152,7 +152,7 @@ ListView {
             y: 272
             width: 185
             height: 27
-            text: qsTr("CPU")
+            text: qsTr("<font color=\"white\">CPU</font>")
             bottomPadding: 5
             onToggled: {
                 appBridge.selectReportingOptions(tempSwitch.checked, cpuSwitch.checked, memSwitch.checked)
@@ -165,7 +165,7 @@ ListView {
             y: 305
             width: 185
             height: 27
-            text: qsTr("Memory")
+            text: qsTr("<font color=\"white\">Memory</font>")
             bottomPadding: 5
             onToggled: {
                 appBridge.selectReportingOptions(tempSwitch.checked, cpuSwitch.checked, memSwitch.checked)
@@ -242,12 +242,12 @@ ListView {
 
         Switch {
             id: consentSwitch
-            x: 350
+            x: 330
             y: 40
             checked: statisticsAccepted
-            width: 250
+            width: 270
             height: 27
-            text: qsTr("Send anonymous usage data")
+            text: qsTr("<font color=\"white\">Send anonymous usage data</font>")
             bottomPadding: 5
             onToggled: {
                 appBridge.toggleStatisticsConsent(consentSwitch.checked)


### PR DESCRIPTION
In this PR, using a little hack, I was able to make all labels clearly visible in Qt UI.

### Before
<img width="603" alt="Screenshot 2021-12-03 at 18 03 05" src="https://user-images.githubusercontent.com/5244214/144642889-107f376e-5e6e-4081-87e8-dad52868fb72.png">

### After
<img width="603" alt="Screenshot 2021-12-03 at 18 00 51" src="https://user-images.githubusercontent.com/5244214/144642811-1eb2759f-9749-41b4-9fa4-66407225236f.png">
