### PR TITLE
Ubuntu 18.04 fix

### DIFF
--- a/depthai_demo.py
+++ b/depthai_demo.py
@@ -494,7 +494,7 @@ def prepareConfManager(in_args):
 def runQt():
     import importlib
     xcb_qt = Path(next(iter(importlib.util.find_spec('PyQt5').submodule_search_locations))) / "Qt5/plugins/platforms/libqxcb.so"
-    os.environ["QT_QPA_PLATFORM_PLUGIN_PATH"] = xcb_qt
+    os.environ["QT_QPA_PLATFORM_PLUGIN_PATH"] = str(xcb_qt)
     os.environ["QT_QUICK_BACKEND"] = "software"
     from gui.main import DemoQtGui, ImageWriter
     from PyQt5.QtWidgets import QMessageBox

--- a/depthai_demo.py
+++ b/depthai_demo.py
@@ -9,6 +9,8 @@ from functools import cmp_to_key
 from itertools import cycle
 from pathlib import Path
 
+import cv2
+
 try:
     from PyQt5.QtCore import QLibraryInfo
     os.environ["LD_LIBRARY_PATH"] = QLibraryInfo.location(QLibraryInfo.LibrariesPath)
@@ -17,8 +19,6 @@ try:
     qt_available = True
 except:
     qt_available = False
-
-import cv2
 
 os.environ["DEPTHAI_INSTALL_SIGNAL_HANDLER"] = "0"
 import depthai as dai

--- a/depthai_demo.py
+++ b/depthai_demo.py
@@ -9,9 +9,10 @@ from functools import cmp_to_key
 from itertools import cycle
 from pathlib import Path
 
-os.environ["QT_QPA_PLATFORM"] = "minimal"
 import cv2
-os.environ["QT_QPA_PLATFORM"] = "xcb"
+for k, v in os.environ.items():
+    if k.startswith("QT_") and "cv2" in v:
+        del os.environ[k]
 
 os.environ["DEPTHAI_INSTALL_SIGNAL_HANDLER"] = "0"
 import depthai as dai

--- a/depthai_demo.py
+++ b/depthai_demo.py
@@ -496,6 +496,7 @@ def runQt():
     from gui.main import DemoQtGui
     from PyQt5.QtWidgets import QMessageBox
     from PyQt5.QtCore import QObject, pyqtSignal, QRunnable, QThreadPool
+    os.environ["LD_LIBRARY_PATH"] = QLibraryInfo.location(QLibraryInfo.LibrariesPath)
     os.environ["QT_QPA_PLATFORM_PLUGIN_PATH"] = QLibraryInfo.location(QLibraryInfo.PluginsPath)
     os.environ["QT_QUICK_BACKEND"] = "software"
 

--- a/depthai_demo.py
+++ b/depthai_demo.py
@@ -9,7 +9,10 @@ from functools import cmp_to_key
 from itertools import cycle
 from pathlib import Path
 
+os.environ["QT_QPA_PLATFORM"] = "minimal"
 import cv2
+os.environ["QT_QPA_PLATFORM"] = "xcb"
+
 os.environ["DEPTHAI_INSTALL_SIGNAL_HANDLER"] = "0"
 import depthai as dai
 import platform

--- a/depthai_demo.py
+++ b/depthai_demo.py
@@ -13,7 +13,8 @@ import cv2
 
 try:
     from PyQt5.QtCore import QLibraryInfo
-    os.environ["LD_LIBRARY_PATH"] = QLibraryInfo.location(QLibraryInfo.LibrariesPath)
+    from ctypes import cdll
+    cdll.LoadLibrary(QLibraryInfo.location(QLibraryInfo.PluginsPath) + "libqxcb.so")
     os.environ["QT_QPA_PLATFORM_PLUGIN_PATH"] = QLibraryInfo.location(QLibraryInfo.PluginsPath)
     os.environ["QT_QUICK_BACKEND"] = "software"
     qt_available = True

--- a/depthai_demo.py
+++ b/depthai_demo.py
@@ -14,7 +14,7 @@ import cv2
 try:
     from PyQt5.QtCore import QLibraryInfo
     from ctypes import cdll
-    cdll.LoadLibrary(QLibraryInfo.location(QLibraryInfo.PluginsPath) + "/libqxcb.so")
+    cdll.LoadLibrary(QLibraryInfo.location(QLibraryInfo.PluginsPath) + "/platforms/libqxcb.so")
     os.environ["QT_QPA_PLATFORM_PLUGIN_PATH"] = QLibraryInfo.location(QLibraryInfo.PluginsPath)
     os.environ["QT_QUICK_BACKEND"] = "software"
     qt_available = True

--- a/depthai_demo.py
+++ b/depthai_demo.py
@@ -13,8 +13,6 @@ import cv2
 
 try:
     from PyQt5.QtCore import QLibraryInfo
-    from ctypes import cdll
-    cdll.LoadLibrary(QLibraryInfo.location(QLibraryInfo.PluginsPath) + "/platforms/libqxcb.so")
     os.environ["QT_QPA_PLATFORM_PLUGIN_PATH"] = QLibraryInfo.location(QLibraryInfo.PluginsPath)
     os.environ["QT_QUICK_BACKEND"] = "software"
     qt_available = True
@@ -887,8 +885,10 @@ def runOpenCv():
 
 
 if __name__ == "__main__":
-    use_cv = args.guiType == "cv" or not qt_available
+    if args.guiType == "qt" and not qt_available:
+        raise RuntimeError("QT backend is not available, run the script with --guiType \"cv\" to use OpenCV backend")
 
+    use_cv = args.guiType == "cv" or not qt_available
     if use_cv:
         args.guiType = "cv"
         runOpenCv()

--- a/depthai_demo.py
+++ b/depthai_demo.py
@@ -492,15 +492,12 @@ def prepareConfManager(in_args):
 
 
 def runQt():
-    import importlib
-    xcb_qt = Path(next(iter(importlib.util.find_spec('PyQt5').submodule_search_locations))) / "Qt5/plugins/platforms/libqxcb.so"
-    del os.environ["QT_QPA_FONTDIR"]
-    os.environ["QT_QPA_PLATFORM_PLUGIN_PATH"] = str(xcb_qt)
-    os.environ["QT_QUICK_BACKEND"] = "software"
-    from gui.main import DemoQtGui, ImageWriter
+    from PyQt5.QtCore import QLibraryInfo
+    from gui.main import DemoQtGui
     from PyQt5.QtWidgets import QMessageBox
-    from PyQt5.QtGui import QImage
-    from PyQt5.QtCore import QObject, pyqtSignal, pyqtSlot, QRunnable, QThreadPool
+    from PyQt5.QtCore import QObject, pyqtSignal, QRunnable, QThreadPool
+    os.environ["QT_QPA_PLATFORM_PLUGIN_PATH"] = QLibraryInfo.location(QLibraryInfo.PluginsPath)
+    os.environ["QT_QUICK_BACKEND"] = "software"
 
 
     class WorkerSignals(QObject):

--- a/depthai_demo.py
+++ b/depthai_demo.py
@@ -494,6 +494,7 @@ def prepareConfManager(in_args):
 def runQt():
     import importlib
     xcb_qt = Path(next(iter(importlib.util.find_spec('PyQt5').submodule_search_locations))) / "Qt5/plugins/platforms/libqxcb.so"
+    del os.environ["QT_QPA_FONTDIR"]
     os.environ["QT_QPA_PLATFORM_PLUGIN_PATH"] = str(xcb_qt)
     os.environ["QT_QUICK_BACKEND"] = "software"
     from gui.main import DemoQtGui, ImageWriter

--- a/depthai_demo.py
+++ b/depthai_demo.py
@@ -14,7 +14,7 @@ import cv2
 try:
     from PyQt5.QtCore import QLibraryInfo
     from ctypes import cdll
-    cdll.LoadLibrary(QLibraryInfo.location(QLibraryInfo.PluginsPath) + "libqxcb.so")
+    cdll.LoadLibrary(QLibraryInfo.location(QLibraryInfo.PluginsPath) + "/libqxcb.so")
     os.environ["QT_QPA_PLATFORM_PLUGIN_PATH"] = QLibraryInfo.location(QLibraryInfo.PluginsPath)
     os.environ["QT_QUICK_BACKEND"] = "software"
     qt_available = True

--- a/depthai_demo.py
+++ b/depthai_demo.py
@@ -493,10 +493,10 @@ def prepareConfManager(in_args):
 
 def runQt():
     from PyQt5.QtCore import QLibraryInfo
+    os.environ["LD_LIBRARY_PATH"] = QLibraryInfo.location(QLibraryInfo.LibrariesPath)
     from gui.main import DemoQtGui
     from PyQt5.QtWidgets import QMessageBox
     from PyQt5.QtCore import QObject, pyqtSignal, QRunnable, QThreadPool
-    os.environ["LD_LIBRARY_PATH"] = QLibraryInfo.location(QLibraryInfo.LibrariesPath)
     os.environ["QT_QPA_PLATFORM_PLUGIN_PATH"] = QLibraryInfo.location(QLibraryInfo.PluginsPath)
     os.environ["QT_QUICK_BACKEND"] = "software"
 

--- a/depthai_demo.py
+++ b/depthai_demo.py
@@ -10,9 +10,6 @@ from itertools import cycle
 from pathlib import Path
 
 import cv2
-for k, v in os.environ.items():
-    if k.startswith("QT_") and "cv2" in v:
-        del os.environ[k]
 
 os.environ["DEPTHAI_INSTALL_SIGNAL_HANDLER"] = "0"
 import depthai as dai
@@ -495,6 +492,9 @@ def prepareConfManager(in_args):
 
 
 def runQt():
+    import importlib
+    xcb_qt = Path(next(iter(importlib.util.find_spec('PyQt5').submodule_search_locations))) / "Qt5/plugins/platforms/libqxcb.so"
+    os.environ["QT_QPA_PLATFORM_PLUGIN_PATH"] = xcb_qt
     os.environ["QT_QUICK_BACKEND"] = "software"
     from gui.main import DemoQtGui, ImageWriter
     from PyQt5.QtWidgets import QMessageBox

--- a/depthai_demo.py
+++ b/depthai_demo.py
@@ -9,6 +9,15 @@ from functools import cmp_to_key
 from itertools import cycle
 from pathlib import Path
 
+try:
+    from PyQt5.QtCore import QLibraryInfo
+    os.environ["LD_LIBRARY_PATH"] = QLibraryInfo.location(QLibraryInfo.LibrariesPath)
+    os.environ["QT_QPA_PLATFORM_PLUGIN_PATH"] = QLibraryInfo.location(QLibraryInfo.PluginsPath)
+    os.environ["QT_QUICK_BACKEND"] = "software"
+    qt_available = True
+except:
+    qt_available = False
+
 import cv2
 
 os.environ["DEPTHAI_INSTALL_SIGNAL_HANDLER"] = "0"
@@ -492,13 +501,9 @@ def prepareConfManager(in_args):
 
 
 def runQt():
-    from PyQt5.QtCore import QLibraryInfo
-    os.environ["LD_LIBRARY_PATH"] = QLibraryInfo.location(QLibraryInfo.LibrariesPath)
     from gui.main import DemoQtGui
     from PyQt5.QtWidgets import QMessageBox
     from PyQt5.QtCore import QObject, pyqtSignal, QRunnable, QThreadPool
-    os.environ["QT_QPA_PLATFORM_PLUGIN_PATH"] = QLibraryInfo.location(QLibraryInfo.PluginsPath)
-    os.environ["QT_QUICK_BACKEND"] = "software"
 
 
     class WorkerSignals(QObject):
@@ -881,15 +886,8 @@ def runOpenCv():
 
 
 if __name__ == "__main__":
-    use_cv = args.guiType == "cv"
-    if not use_cv:
-        try:
-            import PyQt5
-        except:
-            if args.guiType == "qt":
-                raise
-            else:
-                use_cv = True
+    use_cv = args.guiType == "cv" or not qt_available
+
     if use_cv:
         args.guiType = "cv"
         runOpenCv()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,9 @@ argcomplete==1.12.1
 opencv-python==4.5.4.58 ; platform_machine != "aarch64" and platform_machine != "armv6l" and platform_machine != "armv7l" and python_version == "3.10"
 opencv-python==4.5.1.48 ; platform_machine != "aarch64" and platform_machine != "armv6l" and platform_machine != "armv7l" and python_version != "3.10"
 opencv-contrib-python==4.5.4.58 ; platform_machine != "aarch64" and platform_machine != "armv6l" and platform_machine != "armv7l" and python_version == "3.10"
-opencv-contrib-python==4.5.1.48 ; platform_machine != "aarch64" and platform_machine != "armv6l" and platform_machine != "armv7l" and python_version != "3.10"
+opencv-contrib-python==4.1.0.25 ; platform_machine != "aarch64" and platform_machine != "armv6l" and platform_machine != "armv7l" and python_version != "3.10"
 opencv-python==4.4.0.46 ; platform_machine == "armv6l" or platform_machine == "armv7l"
-opencv-contrib-python==4.1.0.25 ; platform_machine == "armv6l" or platform_machine == "armv7l"
+opencv-contrib-python==4.4.0.46 ; platform_machine == "armv6l" or platform_machine == "armv7l"
 -e ./depthai_sdk
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-depthai-data-local/wheels/
 pyqt5>5,<6 ; platform_machine != "armv6l" and platform_machine != "armv7l"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ argcomplete==1.12.1
 opencv-python==4.5.4.58 ; platform_machine != "aarch64" and platform_machine != "armv6l" and platform_machine != "armv7l" and python_version == "3.10"
 opencv-python==4.5.1.48 ; platform_machine != "aarch64" and platform_machine != "armv6l" and platform_machine != "armv7l" and python_version != "3.10"
 opencv-contrib-python==4.5.4.58 ; platform_machine != "aarch64" and platform_machine != "armv6l" and platform_machine != "armv7l" and python_version == "3.10"
-opencv-contrib-python==4.1.0.25 ; platform_machine != "aarch64" and platform_machine != "armv6l" and platform_machine != "armv7l" and python_version != "3.10"
+opencv-contrib-python==4.5.1.48 ; platform_machine != "aarch64" and platform_machine != "armv6l" and platform_machine != "armv7l" and python_version != "3.10"
 opencv-python==4.4.0.46 ; platform_machine == "armv6l" or platform_machine == "armv7l"
 opencv-contrib-python==4.4.0.46 ; platform_machine == "armv6l" or platform_machine == "armv7l"
 -e ./depthai_sdk

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ opencv-python==4.5.1.48 ; platform_machine != "aarch64" and platform_machine != 
 opencv-contrib-python==4.5.4.58 ; platform_machine != "aarch64" and platform_machine != "armv6l" and platform_machine != "armv7l" and python_version == "3.10"
 opencv-contrib-python==4.5.1.48 ; platform_machine != "aarch64" and platform_machine != "armv6l" and platform_machine != "armv7l" and python_version != "3.10"
 opencv-python==4.4.0.46 ; platform_machine == "armv6l" or platform_machine == "armv7l"
-opencv-contrib-python==4.4.0.46 ; platform_machine == "armv6l" or platform_machine == "armv7l"
+opencv-contrib-python==4.1.0.25 ; platform_machine == "armv6l" or platform_machine == "armv7l"
 -e ./depthai_sdk
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-depthai-data-local/wheels/
 pyqt5>5,<6 ; platform_machine != "armv6l" and platform_machine != "armv7l"


### PR DESCRIPTION
Currently, on Ubuntu 18.04, users running our demo will experience the following error (reported here - https://github.com/luxonis/depthai/issues/568)

```
QObject::moveToThread: Current thread (0x20b69f0) is not the object's thread (0x20e92f0).
Cannot move to target thread (0x20b69f0)

qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "/home/burner1/.local/lib/python3.6/site-packages/cv2/qt/plugins" even though it was found.
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
```
This PR enables Qt GUI to work on this OS but requires setting an env flag prior.

The root cause of this issue is the conflict between the installed Qt version and the Qt version installed by OpenCV. To solve this, I had to both downgrade opencv-contrib-python and set additional env flags.

To run the Qt GUI on Ubuntu as of now, use the following command

```
$ export LD_LIBRARY_PATH="$HOME/.local/lib/python3.6/site-packages/PyQt5/Qt5/lib/
$ python3 depthai_demo.py
```

I was not successful however in enabling this variable by default, trying various solutions without success. One thing I want to explore further is by dynamically loading the required .so files, as [mentioned here](https://stackoverflow.com/a/21665823/5494277)