### PR TITLE
exclude latest version of Qt due to Windows issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,6 @@ opencv-python==4.4.0.46 ; platform_machine == "armv6l" or platform_machine == "a
 opencv-contrib-python==4.4.0.46 ; platform_machine == "armv6l" or platform_machine == "armv7l"
 -e ./depthai_sdk
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-depthai-data-local/wheels/
-pyqt5>5,<6 ; platform_machine != "armv6l" and platform_machine != "armv7l"
+pyqt5>5,<5.15.6 ; platform_machine != "armv6l" and platform_machine != "armv7l"
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/
 depthai==2.13.3.0


### PR DESCRIPTION
This PR solves the reported issue on Windows, by preventing 5.15.6 from being installed and thus mitigated the issue below

```
Traceback (most recent call last):
  File "D:\depthai\depthai_demo.py", line 893, in <module>
    runQt()
  File "D:\depthai\depthai_demo.py", line 493, in runQt
    from gui.main import DemoQtGui, ImageWriter
  File "D:\depthai\gui\main.py", line 5, in <module>
    from PyQt5.QtQml import QQmlApplicationEngine, qmlRegisterType, qmlRegisterSingletonType, QQmlEngine
ImportError: DLL load failed while importing QtQml: The specified module could not be found.
```


