### PR TITLE
add fix for Windows paths

### DIFF
--- a/depthai_helpers/supervisor.py
+++ b/depthai_helpers/supervisor.py
@@ -33,7 +33,7 @@ class Supervisor:
             new_env["LD_LIBRARY_PATH"] = str(Path(importlib.util.find_spec("PyQt5").origin).parent / "Qt5/lib")
             new_env["DEPTHAI_INSTALL_SIGNAL_HANDLER"] = "0"
             try:
-                subprocess.check_call(' '.join([sys.executable, "depthai_demo.py"] + new_args), env=new_env, shell=True, cwd=repo_root)
+                subprocess.check_call(' '.join([f'"{sys.executable}"', "depthai_demo.py"] + new_args), env=new_env, shell=True, cwd=repo_root)
             except subprocess.CalledProcessError as ex:
                 print("Error while running demo script... {}".format(ex))
                 print("Waiting 5s for the device to be discoverable again...")
@@ -43,7 +43,7 @@ class Supervisor:
             new_env = env.copy()
             new_env["DEPTHAI_INSTALL_SIGNAL_HANDLER"] = "0"
             new_args = createNewArgs(args)
-            subprocess.check_call(' '.join([sys.executable, "depthai_demo.py"] + new_args), env=new_env, shell=True, cwd=repo_root)
+            subprocess.check_call(' '.join([f'"{sys.executable}"', "depthai_demo.py"] + new_args), env=new_env, shell=True, cwd=repo_root)
 
     def checkQtAvailability(self):
         return importlib.util.find_spec("PyQt5") is not None


### PR DESCRIPTION
This PR fixes the WIndows issue when the path to the interpreter was containing spaces - e.g. `C:\Program Files`. Now, the path is quoted to prevent it