### PR TITLE
Release tweaks

### DIFF
--- a/depthai_demo.py
+++ b/depthai_demo.py
@@ -985,7 +985,6 @@ if __name__ == "__main__":
     try:
         if args.noSupervisor:
             if args.guiType == "qt":
-                sys.setrecursionlimit(10000)
                 runQt()
             else:
                 args.guiType = "cv"

--- a/depthai_demo.py
+++ b/depthai_demo.py
@@ -1,14 +1,19 @@
 #!/usr/bin/env python3
+import sys
+if sys.version_info[0] < 3:
+    raise Exception("Must be using Python 3")
 import argparse
 import json
 import os
-import sys
 import time
 import traceback
 from functools import cmp_to_key
 from itertools import cycle
 from pathlib import Path
 import platform
+
+if platform.machine() == 'aarch64':  # Jetson
+    os.environ['OPENBLAS_CORETYPE'] = "ARMV8"
 
 from depthai_helpers.app_manager import App
 if __name__ == "__main__":

--- a/depthai_demo.py
+++ b/depthai_demo.py
@@ -985,8 +985,7 @@ if __name__ == "__main__":
     try:
         if args.noSupervisor:
             if args.guiType == "qt":
-                sys.setrecursionlimit(100000)
-                threading.stack_size(200000000)
+                sys.setrecursionlimit(10000)
                 runQt()
             else:
                 args.guiType = "cv"

--- a/depthai_demo.py
+++ b/depthai_demo.py
@@ -993,7 +993,12 @@ if __name__ == "__main__":
                 available = s.checkQtAvailability()
                 if args.guiType == "qt" and not available:
                     raise RuntimeError("QT backend is not available, run the script with --guiType \"cv\" to use OpenCV backend")
-                args.guiType = "qt" if available else "cv"
+                if args.guiType == "auto" and platform.machine() == 'aarch64':  # Disable Qt by default on Jetson due to Qt issues
+                    args.guiType = "cv"
+                elif available:
+                    args.guiType = "qt"
+                else:
+                    args.guiType = "cv"
             s.runDemo(args)
     except KeyboardInterrupt:
         sys.exit(0)

--- a/depthai_demo.py
+++ b/depthai_demo.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 import sys
+import threading
+
 if sys.version_info[0] < 3:
     raise Exception("Must be using Python 3")
 import argparse
@@ -983,6 +985,8 @@ if __name__ == "__main__":
     try:
         if args.noSupervisor:
             if args.guiType == "qt":
+                sys.setrecursionlimit(100000)
+                threading.stack_size(200000000)
                 runQt()
             else:
                 args.guiType = "cv"

--- a/depthai_helpers/supervisor.py
+++ b/depthai_helpers/supervisor.py
@@ -1,5 +1,6 @@
 import importlib.util
 import os
+import platform
 import subprocess
 import sys
 import time
@@ -32,6 +33,8 @@ class Supervisor:
             new_env["QT_QUICK_BACKEND"] = "software"
             new_env["LD_LIBRARY_PATH"] = str(Path(importlib.util.find_spec("PyQt5").origin).parent / "Qt5/lib")
             new_env["DEPTHAI_INSTALL_SIGNAL_HANDLER"] = "0"
+            if platform.machine() == 'aarch64':  # Jetson
+                new_env['OPENBLAS_CORETYPE'] = "ARMV8"
             try:
                 subprocess.check_call(' '.join([f'"{sys.executable}"', "depthai_demo.py"] + new_args), env=new_env, shell=True, cwd=repo_root)
             except subprocess.CalledProcessError as ex:

--- a/depthai_helpers/supervisor.py
+++ b/depthai_helpers/supervisor.py
@@ -1,6 +1,5 @@
 import importlib.util
 import os
-import platform
 import subprocess
 import sys
 import time
@@ -33,8 +32,6 @@ class Supervisor:
             new_env["QT_QUICK_BACKEND"] = "software"
             new_env["LD_LIBRARY_PATH"] = str(Path(importlib.util.find_spec("PyQt5").origin).parent / "Qt5/lib")
             new_env["DEPTHAI_INSTALL_SIGNAL_HANDLER"] = "0"
-            if platform.machine() == 'aarch64':  # Jetson
-                new_env['OPENBLAS_CORETYPE'] = "ARMV8"
             try:
                 subprocess.check_call(' '.join([f'"{sys.executable}"', "depthai_demo.py"] + new_args), env=new_env, shell=True, cwd=repo_root)
             except subprocess.CalledProcessError as ex:

--- a/gui/views/AIProperties.qml
+++ b/gui/views/AIProperties.qml
@@ -1,5 +1,5 @@
 import QtQuick 2.0
-import QtQuick.Layouts 1.11
+import QtQuick.Layouts 1.3
 import QtQuick.Controls 2.1
 import QtQuick.Window 2.1
 import QtQuick.Controls.Material 2.1
@@ -166,7 +166,6 @@ ListView {
             font.pointSize: 21
             checked: false
             font.preferShaping: false
-            font.kerning: false
         }
 
         Rectangle {
@@ -243,7 +242,6 @@ ListView {
                 autoExclusive: false
                 transformOrigin: Item.Center
                 font.preferShaping: false
-                font.kerning: false
                 onToggled: {
                     aiBridge.setSbb(switch3.checked)
                 }
@@ -305,7 +303,6 @@ ListView {
             checked: true
             autoExclusive: false
             font.family: "Courier"
-            font.kerning: false
             transformOrigin: Item.Center
             font.preferShaping: false
             onToggled: {

--- a/gui/views/AIProperties.qml
+++ b/gui/views/AIProperties.qml
@@ -165,7 +165,6 @@ ListView {
             transformOrigin: Item.Center
             font.pointSize: 21
             checked: false
-            font.preferShaping: false
         }
 
         Rectangle {
@@ -241,7 +240,6 @@ ListView {
                 font.family: "Courier"
                 autoExclusive: false
                 transformOrigin: Item.Center
-                font.preferShaping: false
                 onToggled: {
                     aiBridge.setSbb(switch3.checked)
                 }
@@ -304,7 +302,6 @@ ListView {
             autoExclusive: false
             font.family: "Courier"
             transformOrigin: Item.Center
-            font.preferShaping: false
             onToggled: {
                 appBridge.toggleNN(switch5.checked)
             }

--- a/gui/views/CameraPreview.qml
+++ b/gui/views/CameraPreview.qml
@@ -1,5 +1,5 @@
 import QtQuick 2.0
-import QtQuick.Layouts 1.11
+import QtQuick.Layouts 1.3
 import QtQuick.Controls 2.1
 import QtQuick.Window 2.1
 import QtQuick.Controls.Material 2.1

--- a/gui/views/CameraProperties.qml
+++ b/gui/views/CameraProperties.qml
@@ -1,5 +1,5 @@
 import QtQuick 2.0
-import QtQuick.Layouts 1.11
+import QtQuick.Layouts 1.3
 import QtQuick.Controls 2.1
 import QtQuick.Window 2.1
 import QtQuick.Controls.Material 2.1
@@ -578,7 +578,6 @@ ListView {
             transformOrigin: Item.Center
             autoExclusive: false
             font.family: "Courier"
-            font.kerning: false
             checked: false
             font.preferShaping: false
         }

--- a/gui/views/CameraProperties.qml
+++ b/gui/views/CameraProperties.qml
@@ -579,7 +579,6 @@ ListView {
             autoExclusive: false
             font.family: "Courier"
             checked: false
-            font.preferShaping: false
         }
     }
 }

--- a/gui/views/DepthProperties.qml
+++ b/gui/views/DepthProperties.qml
@@ -1,5 +1,5 @@
 import QtQuick 2.0
-import QtQuick.Layouts 1.11
+import QtQuick.Layouts 1.3
 import QtQuick.Controls 2.1
 import QtQuick.Window 2.1
 import QtQuick.Controls.Material 2.1
@@ -68,7 +68,6 @@ ListView {
             text: qsTr("<font color=\"white\">Left Right Check</font>")
             transformOrigin: Item.Center
             font.preferShaping: false
-            font.kerning: false
             font.family: "Courier"
             autoExclusive: false
             onToggled: {
@@ -86,7 +85,6 @@ ListView {
             autoExclusive: false
             font.family: "Courier"
             checked: true
-            font.kerning: false
             transformOrigin: Item.Center
             font.preferShaping: false
             onToggled: {
@@ -101,7 +99,6 @@ ListView {
             y: 233
             text: qsTr("<font color=\"white\">Extended Disparity</font>")
             autoExclusive: false
-            font.kerning: false
             font.family: "Courier"
             font.preferShaping: false
             transformOrigin: Item.Center
@@ -116,7 +113,6 @@ ListView {
             y: 141
             text: qsTr("<font color=\"white\">Subpixel</font>")
             autoExclusive: false
-            font.kerning: false
             transformOrigin: Item.Center
             font.preferShaping: false
             font.family: "Courier"
@@ -273,7 +269,6 @@ ListView {
             text: qsTr("<font color=\"white\">Use Disparity</font>")
             autoExclusive: false
             font.family: "Courier"
-            font.kerning: false
             transformOrigin: Item.Center
             font.preferShaping: false
             onToggled: {

--- a/gui/views/DepthProperties.qml
+++ b/gui/views/DepthProperties.qml
@@ -67,7 +67,6 @@ ListView {
             y: 187
             text: qsTr("<font color=\"white\">Left Right Check</font>")
             transformOrigin: Item.Center
-            font.preferShaping: false
             font.family: "Courier"
             autoExclusive: false
             onToggled: {
@@ -86,7 +85,6 @@ ListView {
             font.family: "Courier"
             checked: true
             transformOrigin: Item.Center
-            font.preferShaping: false
             onToggled: {
                 appBridge.toggleDepth(switch5.checked)
             }
@@ -100,7 +98,6 @@ ListView {
             text: qsTr("<font color=\"white\">Extended Disparity</font>")
             autoExclusive: false
             font.family: "Courier"
-            font.preferShaping: false
             transformOrigin: Item.Center
             onToggled: {
                 depthBridge.toggleExtendedDisparity(switch2.checked)
@@ -114,7 +111,6 @@ ListView {
             text: qsTr("<font color=\"white\">Subpixel</font>")
             autoExclusive: false
             transformOrigin: Item.Center
-            font.preferShaping: false
             font.family: "Courier"
             onToggled: {
                 depthBridge.toggleSubpixel(switch3.checked)
@@ -270,7 +266,6 @@ ListView {
             autoExclusive: false
             font.family: "Courier"
             transformOrigin: Item.Center
-            font.preferShaping: false
             onToggled: {
                 appBridge.toggleDisparity(switch6.checked)
             }

--- a/gui/views/MiscProperties.qml
+++ b/gui/views/MiscProperties.qml
@@ -1,5 +1,5 @@
 import QtQuick 2.0
-import QtQuick.Layouts 1.11
+import QtQuick.Layouts 1.3
 import QtQuick.Controls 2.1
 import QtQuick.Window 2.1
 import QtQuick.Controls.Material 2.1

--- a/gui/views/root.qml
+++ b/gui/views/root.qml
@@ -49,7 +49,7 @@
 ****************************************************************************/
 
 import QtQuick 2.0
-import QtQuick.Layouts 1.11
+import QtQuick.Layouts 1.3
 import QtQuick.Controls 2.1
 import QtQuick.Window 2.1
 import QtQuick.Controls.Material 2.1

--- a/install_requirements.py
+++ b/install_requirements.py
@@ -50,25 +50,3 @@ try:
     subprocess.check_call(pip_package_install + ["-r", "requirements-optional.txt"], cwd=scriptDirectory, stderr=subprocess.DEVNULL)
 except subprocess.CalledProcessError as ex:
     print("Optional dependencies were not installed. This is not an error.")
-
-
-if thisPlatform == "aarch64":
-    # try to import opencv, numpy in a subprocess, since it might fail with illegal instruction
-    # if it was previously installed w/ pip without setting OPENBLAS_CORE_TYPE=ARMV8 env variable
-    opencvInstalledProperly = False
-    try:
-        subprocess.check_call([sys.executable, "-c", "import numpy, cv2;"])
-        opencvInstalledProperly = True
-    except subprocess.CalledProcessError as ex:
-        opencvInstalledProperly = False
-
-    if not opencvInstalledProperly:
-        from os import environ
-        OPENBLAS_CORE_TYPE = environ.get('OPENBLAS_CORE_TYPE')
-        if OPENBLAS_CORE_TYPE != 'ARMV8':
-            WARNING='\033[1;5;31m'
-            RED='\033[91m'
-            LINE_CL='\033[0m'
-            SUGGESTION='echo "export OPENBLAS_CORETYPE=ARMV8" >> ~/.bashrc && source ~/.bashrc'
-            print(f'{WARNING}WARNING:{LINE_CL} Need to set OPENBLAS_CORE_TYPE environment variable, otherwise opencv will fail with illegal instruction.')
-            print(f'Run: {RED}{SUGGESTION}{LINE_CL}')

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,4 +1,4 @@
-open3d==0.10.0.0; platform_machine != "armv6l" and platform_machine != "armv7l" and python_version < "3.9"
+open3d==0.10.0.0; platform_machine != "armv6l" and platform_machine != "armv7l" and python_version < "3.9" and platform_machine != "aarch64"
 ffmpy3==0.2.4
 pyusb==1.2.1
 sentry-sdk==1.5.1


### PR DESCRIPTION
This PR adds:
- Adds automatic handle for OPENBLAS_CORETYPE env variable setting for Jetson
- Downgrades QtQuick.Layouts to `1.3` to be available on Ubuntu 18.04
- Adds a correct exception if Python 2 is used
- Disables Qt backend by default on Jetson platforms due to Qt issue (ImageWriter is not painting the frames and it's width accessed from Python is negative)