### PR TITLE
Fixes for Start Menu entry and shortcut icon

### DIFF
--- a/launcher/windows/installer_win64.iss
+++ b/launcher/windows/installer_win64.iss
@@ -97,7 +97,7 @@ Source: "..\{#MyAppIconName}"; DestDir: "{app}"; Flags: ignoreversion
 ; ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 
 [Icons]
-Name: "{autoprograms}\{#MyAppName}"; Filename: "{app}\{#MyAppIconName}"
+Name: "{autoprograms}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"
 Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
 
 [Run]

--- a/launcher/windows/src/create_shortcut.ps1
+++ b/launcher/windows/src/create_shortcut.ps1
@@ -1,9 +1,9 @@
 # Create a DepthAI.lnk with icon
 $WshShell = New-Object -comObject WScript.Shell
 $Shortcut = $WshShell.CreateShortcut("$PSScriptRoot\DepthAI.lnk")
-$Shortcut.TargetPath = "`"$PSScriptRoot\venv\Scripts\python.exe`""
+$Shortcut.TargetPath = "$PSScriptRoot\venv\Scripts\python.exe"
 $Shortcut.Arguments = "`"$PSScriptRoot\depthai\launcher\launcher.py`" --repo `"$PSScriptRoot\depthai`" --git `"$PSScriptRoot\PortableGit\bin\git.exe`""
-$Shortcut.IconLocation = "`"$PSScriptRoot\logo_only_EBl_icon.ico`""
-$Shortcut.WorkingDirectory = "`"$PSScriptRoot`""
+$Shortcut.IconLocation = "$PSScriptRoot\logo_only_EBl_icon.ico"
+$Shortcut.WorkingDirectory = "$PSScriptRoot"
 $Shortcut.WindowStyle = 7 # Minimized
 $Shortcut.Save()


### PR DESCRIPTION
Single arguments don't need to be escaped otherwise the path contains the actual `"` quotes, which makes it invalid.