### PR TITLE
Disable stereo runtime mode switch since it allocates resources for worst case

### DIFF
--- a/depthai_sdk/src/depthai_sdk/managers/pipeline_manager.py
+++ b/depthai_sdk/src/depthai_sdk/managers/pipeline_manager.py
@@ -270,7 +270,7 @@ class PipelineManager:
 
         self._depthConfig = self.nodes.stereo.initialConfig.get()
 
-        self.nodes.stereo.setRuntimeModeSwitch(True)
+        # self.nodes.stereo.setRuntimeModeSwitch(True)
         self.nodes.stereo.setLeftRightCheck(lr)
         self.nodes.stereo.setExtendedDisparity(extended)
         self.nodes.stereo.setSubpixel(subpixel)


### PR DESCRIPTION
Internal discussion about this subject:
https://luxonis.slack.com/archives/C012N7HNN4W/p1637887232073700

Demo is running at 30 fps again.