### PR TITLE
Add pyproject.toml to support poetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,10 @@ To get the versions of these packages you need for the program, use pip: (Make s
 ```
 python3 install_requirements.py
 ```
-
+Or using [poetry](https://python-poetry.org/):
+```
+poetry install
+```
 ## Examples
 
 `python3 depthai_demo.py` - RGB & CNN inference example

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,45 @@
+[tool.poetry]
+name = "depthai-demo"
+version = "0.1.0"
+description = ""
+authors = ["Your Name <you@example.com>"]
+
+[[tool.poetry.source]]
+name = "luxonis"
+url = "https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/"
+secondary = true
+
+#[[tool.poetry.source]]
+#name = "piwheels"
+#url = "https://www.piwheels.org/simple"
+#secondary = false
+
+[tool.poetry.dependencies]
+python ">=3.8,<4"
+requests = "==2.26.0"
+Pyrebase4 = "==4.5"
+argcomplete = "==1.12.1"
+opencv-python = [{version="==4.5.4.58",markers='platform_machine != "aarch64" and platform_machine != "armv6l" and platform_machine != "armv7l" and python_version == "3.10"'},
+{version="==4.5.1.48",markers='platform_machine != "aarch64" and platform_machine != "armv6l" and platform_machine != "armv7l" and python_version != "3.10"'},
+{version="==4.4.0.46",markers='platform_machine == "armv6l" or platform_machine == "armv7l"'}]
+
+opencv-contrib-python = [{version="==4.5.4.58",markers='platform_machine != "aarch64" and platform_machine != "armv6l" and platform_machine != "armv7l" and python_version == "3.10"'},
+{version="==4.5.1.48",markers='platform_machine != "aarch64" and platform_machine != "armv6l" and platform_machine != "armv7l" and python_version != "3.10"'},
+{version="==4.4.0.46",markers='platform_machine == "armv6l" or platform_machine == "armv7l"'}]
+
+depthai = "==2.14.1.0.dev+27fa4519f289498e84768ab5229a1a45efb7e4df"
+depthai-sdk = {path = "depthai_sdk"}
+pyqt5 = {version=">5,<5.15.6", markers='platform_machine != "armv6l" and platform_machine != "armv7l" and platform_machine != "aarch64"'}
+
+
+[tool.poetry.dev-dependencies]
+ffmpy3 = "==0.2.4"
+pyusb= "==1.2.1"
+sentry-sdk = "==1.5.2"
+open3d = {version="==0.10.0.0", markers ='platform_machine != "armv6l" and platform_machine != "armv7l" and python_version < "3.9" and platform_machine != "aarch64"'}
+
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,14 +9,14 @@ name = "luxonis"
 url = "https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/"
 secondary = true
 
-#[[tool.poetry.source]]
-#name = "piwheels"
-#url = "https://www.piwheels.org/simple"
-#secondary = false
+[[tool.poetry.source]]
+name = "piwheels"
+url = "https://www.piwheels.org/simple"
+secondary = true
 
 [tool.poetry.dependencies]
-python ">=3.8,<4"
-pip=">=21.3.1"
+python = ">=3.8,<4"
+pip=">=21.5.1"
 requests = "==2.26.0"
 Pyrebase4 = "==4.5"
 argcomplete = "==1.12.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ secondary = true
 
 [tool.poetry.dependencies]
 python ">=3.8,<4"
+pip=">=21.3.1"
 requests = "==2.26.0"
 Pyrebase4 = "==4.5"
 argcomplete = "==1.12.1"


### PR DESCRIPTION
Poetry uses pyproject.toml after [PEP 518](https://www.python.org/dev/peps/pep-0518/)

More about poetry: https://python-poetry.org/ 

To install the requirements simply type in the folder of the pyproject.toml: 
`poetry install `

Poetry creates a virtual environment for you and installs the defined dependencies from the pyproject.toml file.

Then execute the code using poetry: 
`poetry run python3 depthai_demo.py
`

The process of solving the dependencies took a while for poetry, not sure why.

Is there a reason for the pywheels source in the requiremtns.txt 

Tested on ubuntu 18.04 with python3.8.

![image](https://user-images.githubusercontent.com/2640499/149721672-31fbe650-fd29-4062-91f0-9ddab2db7380.png)

I could run the demo, but I do not have a device yet, that's why I see the error.