### PR TITLE
Enable CLI params in apps, tweak app setup and termination and disable UVC app with USB2 connections

### DIFF
--- a/apps/uvc/main.py
+++ b/apps/uvc/main.py
@@ -31,8 +31,12 @@ else:
 uvc = pipeline.createUVC()
 cam_rgb.video.link(uvc.input)
 
+
 # Pipeline defined, now the device is connected to
 with dai.Device(pipeline, usb2Mode=args.usbSpeed == "usb2") as device:
+    if device.getDeviceInfo().desc.protocol == dai.XLinkProtocol.X_LINK_USB_VSC and device.getUsbSpeed() not in (dai.UsbSpeed.SUPER, dai.UsbSpeed.SUPER_PLUS):
+        print("This app is temporarily disabled with USB2 connection speed due to known issue. We're working on resolving it. In the meantime, please try again with a USB3 cable/port for the device connection")
+        raise SystemExit(0)
     print("\nDevice started, please keep this process running")
     print("and open an UVC viewer. Example on Linux:")
     print("    guvcview -d /dev/video0")

--- a/apps/uvc/main.py
+++ b/apps/uvc/main.py
@@ -2,13 +2,14 @@
 import platform
 import depthai as dai
 import time
+import sys
 from depthai_helpers.arg_manager import parseArgs
 
 args = parseArgs()
 
 
 if platform.machine() == 'aarch64':
-    print("This app is temporarily disabled on AARCH64 systems due to an issue with stream preview. We are working on resolving this issue")
+    print("This app is temporarily disabled on AARCH64 systems due to an issue with stream preview. We are working on resolving this issue", file=sys.stderr)
     raise SystemExit(1)
 
 enable_4k = True  # Will downscale 4K -> 1080p
@@ -35,7 +36,7 @@ cam_rgb.video.link(uvc.input)
 # Pipeline defined, now the device is connected to
 with dai.Device(pipeline, usb2Mode=args.usbSpeed == "usb2") as device:
     if device.getDeviceInfo().desc.protocol == dai.XLinkProtocol.X_LINK_USB_VSC and device.getUsbSpeed() not in (dai.UsbSpeed.SUPER, dai.UsbSpeed.SUPER_PLUS):
-        print("This app is temporarily disabled with USB2 connection speed due to known issue. We're working on resolving it. In the meantime, please try again with a USB3 cable/port for the device connection")
+        print("This app is temporarily disabled with USB2 connection speed due to known issue. We're working on resolving it. In the meantime, please try again with a USB3 cable/port for the device connection", file=sys.stderr)
         raise SystemExit(1)
     print("\nDevice started, please keep this process running")
     print("and open an UVC viewer. Example on Linux:")

--- a/apps/uvc/main.py
+++ b/apps/uvc/main.py
@@ -6,6 +6,7 @@ from depthai_helpers.arg_manager import parseArgs
 
 args = parseArgs()
 
+
 if platform.machine() == 'aarch64':
     print("This app is temporarily disabled on AARCH64 systems due to an issue with stream preview. We are working on resolving this issue")
     raise SystemExit(0)

--- a/apps/uvc/main.py
+++ b/apps/uvc/main.py
@@ -9,7 +9,7 @@ args = parseArgs()
 
 if platform.machine() == 'aarch64':
     print("This app is temporarily disabled on AARCH64 systems due to an issue with stream preview. We are working on resolving this issue")
-    raise SystemExit(0)
+    raise SystemExit(1)
 
 enable_4k = True  # Will downscale 4K -> 1080p
 
@@ -36,7 +36,7 @@ cam_rgb.video.link(uvc.input)
 with dai.Device(pipeline, usb2Mode=args.usbSpeed == "usb2") as device:
     if device.getDeviceInfo().desc.protocol == dai.XLinkProtocol.X_LINK_USB_VSC and device.getUsbSpeed() not in (dai.UsbSpeed.SUPER, dai.UsbSpeed.SUPER_PLUS):
         print("This app is temporarily disabled with USB2 connection speed due to known issue. We're working on resolving it. In the meantime, please try again with a USB3 cable/port for the device connection")
-        raise SystemExit(0)
+        raise SystemExit(1)
     print("\nDevice started, please keep this process running")
     print("and open an UVC viewer. Example on Linux:")
     print("    guvcview -d /dev/video0")

--- a/apps/uvc/main.py
+++ b/apps/uvc/main.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python3
-import os
 import platform
 import depthai as dai
 import time
-
 from depthai_helpers.arg_manager import parseArgs
 
 args = parseArgs()

--- a/apps/uvc/main.py
+++ b/apps/uvc/main.py
@@ -4,6 +4,10 @@ import platform
 import depthai as dai
 import time
 
+from depthai_helpers.arg_manager import parseArgs
+
+args = parseArgs()
+
 if platform.machine() == 'aarch64':
     print("This app is temporarily disabled on AARCH64 systems due to an issue with stream preview. We are working on resolving this issue")
     raise SystemExit(0)
@@ -29,7 +33,7 @@ uvc = pipeline.createUVC()
 cam_rgb.video.link(uvc.input)
 
 # Pipeline defined, now the device is connected to
-with dai.Device(pipeline) as device:
+with dai.Device(pipeline, usb2Mode=args.usbSpeed == "usb2") as device:
     print("\nDevice started, please keep this process running")
     print("and open an UVC viewer. Example on Linux:")
     print("    guvcview -d /dev/video0")

--- a/depthai_helpers/app_manager.py
+++ b/depthai_helpers/app_manager.py
@@ -7,6 +7,7 @@ import time
 from pathlib import Path
 
 initEnv = os.environ.copy()
+initEnv["PYTHONPATH"] = ":".join(initEnv.get("PYTHONPATH", "").split(":") + [str(Path(__file__).parent.parent.absolute())])
 
 
 def quoted(val):

--- a/depthai_helpers/app_manager.py
+++ b/depthai_helpers/app_manager.py
@@ -67,7 +67,7 @@ class App:
             except KeyboardInterrupt:
                 break
         if os.name == 'nt':
-            os.kill(pro.pid, signal.SIGTERM)
+            subprocess.call(['taskkill', '/F', '/T', '/PID', str(pro.pid)])
         else:
             os.killpg(os.getpgid(pro.pid), signal.SIGTERM)
 

--- a/depthai_helpers/app_manager.py
+++ b/depthai_helpers/app_manager.py
@@ -61,13 +61,14 @@ class App:
             pro = subprocess.Popen(' '.join([quoted(self.appInterpreter), quoted(str(self.appEntrypoint))]), env=initEnv, shell=True, cwd=self.appPath)
         else:
             pro = subprocess.Popen(' '.join([quoted(self.appInterpreter), quoted(str(self.appEntrypoint))]), env=initEnv, shell=True, cwd=self.appPath, preexec_fn=os.setsid)
-        while shouldRun():
+        while shouldRun() and pro.poll() is None:
             try:
                 time.sleep(1)
             except KeyboardInterrupt:
                 break
-        if os.name == 'nt':
-            subprocess.call(['taskkill', '/F', '/T', '/PID', str(pro.pid)])
-        else:
-            os.killpg(os.getpgid(pro.pid), signal.SIGTERM)
+        if pro.poll() is not None:
+            if os.name == 'nt':
+                subprocess.call(['taskkill', '/F', '/T', '/PID', str(pro.pid)])
+            else:
+                os.kill(pro.pid, signal.SIGTERM)
 

--- a/depthai_helpers/app_manager.py
+++ b/depthai_helpers/app_manager.py
@@ -67,8 +67,12 @@ class App:
             except KeyboardInterrupt:
                 break
         if pro.poll() is not None:
-            if os.name == 'nt':
-                subprocess.call(['taskkill', '/F', '/T', '/PID', str(pro.pid)])
-            else:
-                os.kill(pro.pid, signal.SIGTERM)
+            try:
+                if os.name == 'nt':
+                    subprocess.call(['taskkill', '/F', '/T', '/PID', str(pro.pid)])
+                else:
+                    os.kill(pro.pid, signal.SIGTERM)
+            except ProcessLookupError:
+                pass
+
 

--- a/depthai_helpers/app_manager.py
+++ b/depthai_helpers/app_manager.py
@@ -7,7 +7,11 @@ import time
 from pathlib import Path
 
 initEnv = os.environ.copy()
-initEnv["PYTHONPATH"] = ":".join(initEnv.get("PYTHONPATH", "").split(":") + [str(Path(__file__).parent.parent.absolute())])
+if "PYTHONPATH" in initEnv:
+    initEnv["PYTHONPATH"] += ":" + str(Path(__file__).parent.parent.absolute())
+else:
+    initEnv["PYTHONPATH"] = str(Path(__file__).parent.parent.absolute())
+
 
 
 def quoted(val):
@@ -62,5 +66,8 @@ class App:
                 time.sleep(1)
             except KeyboardInterrupt:
                 break
-        os.killpg(os.getpgid(pro.pid), signal.SIGTERM)
+        if os.name == 'nt':
+            os.kill(pro.pid, signal.SIGTERM)
+        else:
+            os.killpg(os.getpgid(pro.pid), signal.SIGTERM)
 

--- a/depthai_helpers/app_manager.py
+++ b/depthai_helpers/app_manager.py
@@ -43,19 +43,19 @@ class App:
             else:
                 print("Creating venv...")
             try:
-                subprocess.check_call(' '.join([quoted(sys.executable), '-m', 'venv', str(self.venvPath)]), shell=True, env=initEnv, cwd=self.appPath)
+                subprocess.check_call(' '.join([quoted(sys.executable), '-m', 'venv', quoted(str(self.venvPath.absolute()))]), shell=True, env=initEnv, cwd=self.appPath)
             except:
                 print(f"Error creating a new virtual environment using \"venv\" module! Please try to install \"python3.{sys.version_info[1]}-venv\" again", file=sys.stderr)
                 sys.exit(1)
         print("Installing requirements...")
         subprocess.check_call(' '.join([quoted(self.appInterpreter), '-m', 'pip', 'install', '-U', 'pip']), env=initEnv, shell=True, cwd=self.appPath)
-        subprocess.check_call(' '.join([quoted(self.appInterpreter), '-m', 'pip', 'install', '--prefer-binary', '-r', str(self.appRequirements)]), env=initEnv, shell=True, cwd=self.appPath)
+        subprocess.check_call(' '.join([quoted(self.appInterpreter), '-m', 'pip', 'install', '--prefer-binary', '-r', quoted(str(self.appRequirements))]), env=initEnv, shell=True, cwd=self.appPath)
 
     def runApp(self, shouldRun = lambda: True):
         if os.name == 'nt':
-            pro = subprocess.Popen(' '.join([quoted(self.appInterpreter), str(self.appEntrypoint)]), env=initEnv, shell=True, cwd=self.appPath)
+            pro = subprocess.Popen(' '.join([quoted(self.appInterpreter), quoted(str(self.appEntrypoint))]), env=initEnv, shell=True, cwd=self.appPath)
         else:
-            pro = subprocess.Popen(' '.join([quoted(self.appInterpreter), str(self.appEntrypoint)]), env=initEnv, shell=True, cwd=self.appPath, preexec_fn=os.setsid)
+            pro = subprocess.Popen(' '.join([quoted(self.appInterpreter), quoted(str(self.appEntrypoint))]), env=initEnv, shell=True, cwd=self.appPath, preexec_fn=os.setsid)
         while shouldRun():
             try:
                 time.sleep(1)

--- a/depthai_helpers/arg_manager.py
+++ b/depthai_helpers/arg_manager.py
@@ -1,13 +1,6 @@
-import os
 import argparse
 from pathlib import Path
-import cv2
 import depthai as dai
-try:
-    import argcomplete
-except ImportError:
-    raise ImportError('\033[1;5;31m argcomplete module not found, run: python3 install_requirements.py \033[0m')
-from depthai_sdk.previews import Previews
 
 
 def checkRange(minVal, maxVal):
@@ -55,12 +48,16 @@ def orientationCast(arg):
 
 openvinoVersions = list(map(lambda name: name.replace("VERSION_", ""), filter(lambda name: name.startswith("VERSION_"), vars(dai.OpenVINO.Version))))
 _streamChoices = ("nnInput", "color", "left", "right", "depth", "depthRaw", "disparity", "disparityColor", "rectifiedLeft", "rectifiedRight")
-colorMaps = list(map(lambda name: name[len("COLORMAP_"):], filter(lambda name: name.startswith("COLORMAP_"), vars(cv2))))
+try:
+    import cv2
+    colorMaps = list(map(lambda name: name[len("COLORMAP_"):], filter(lambda name: name.startswith("COLORMAP_"), vars(cv2))))
+except:
+    colorMaps = None
 projectRoot = Path(__file__).parent.parent
 
 def parseArgs():
     parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
-    parser.add_argument('-cam', '--camera', choices=[Previews.left.name, Previews.right.name, Previews.color.name], default=Previews.color.name, help="Use one of DepthAI cameras for inference (conflicts with -vid)")
+    parser.add_argument('-cam', '--camera', choices=["left", "right", "color"], default="color", help="Use one of DepthAI cameras for inference (conflicts with -vid)")
     parser.add_argument('-vid', '--video', type=str, help="Path to video file (or YouTube link) to be used for inference (conflicts with -cam)")
     parser.add_argument('-dd', '--disableDepth', action="store_true", help="Disable depth information")
     parser.add_argument('-dnn', '--disableNeuralNetwork', action="store_true", help="Disable neural network inference")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 requests==2.26.0
 pyrebase4==4.5
-argcomplete==1.12.1
 --extra-index-url https://www.piwheels.org/simple
 opencv-python==4.5.4.58 ; platform_machine != "aarch64" and platform_machine != "armv6l" and platform_machine != "armv7l" and python_version == "3.10"
 opencv-python==4.5.1.48 ; platform_machine != "aarch64" and platform_machine != "armv6l" and platform_machine != "armv7l" and python_version != "3.10"


### PR DESCRIPTION
in this PR:
- Setup and terminate process is modified to correctly handle different OSes (tested on Windows and Mac)
- Removed argcomplete dependency (as we're moving more into GUI and having it listed would require demo apps to have it as well)
- Enabled same CLI arguments parsing for the apps as it is now for the demo
- Disabled UVC app is connection speed is USB2 due to #616