### PR TITLE
Append both demo directory and sdk into path before imports

### DIFF
--- a/depthai_demo.py
+++ b/depthai_demo.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 import sys
-import threading
 
 if sys.version_info[0] < 3:
     raise Exception("Must be using Python 3")
@@ -16,6 +15,9 @@ import platform
 
 if platform.machine() == 'aarch64':  # Jetson
     os.environ['OPENBLAS_CORETYPE'] = "ARMV8"
+
+sys.path.append(str(Path(__file__).parent.absolute()))
+sys.path.append(str((Path(__file__).parent / "depthai_sdk" / "src").absolute()))
 
 from depthai_helpers.app_manager import App
 if __name__ == "__main__":


### PR DESCRIPTION
This issue resolves a case when `depthai_sdk` package could not be found - either due to not installing requirements or `depthai_sdk` package installation fails