### PR TITLE
Installer improvements

### DIFF
--- a/.github/workflows/demo.workflow.yml
+++ b/.github/workflows/demo.workflow.yml
@@ -28,11 +28,11 @@ jobs:
 
     - name: Set version (Release)
       if: startsWith(github.ref, 'refs/tags/v') == true
-      run: echo '#define MyAppVersion "${{ steps.tag.outputs.version-without-v }}"' >| version.txt
+      run: echo '#define MyAppVersion "${{ steps.tag.outputs.version-without-v }}"' > version.txt
 
     - name: Set version
       if: startsWith(github.ref, 'refs/tags/v') != true
-      run: echo '#define MyAppVersion "1.0-${{ github.sha }}"' >| version.txt
+      run: echo '#define MyAppVersion "1.0-${{ github.sha }}"' > version.txt
 
     - name: Build Windows Installer
       run: .\launcher\windows\build.ps1

--- a/.github/workflows/demo.workflow.yml
+++ b/.github/workflows/demo.workflow.yml
@@ -22,6 +22,18 @@ jobs:
         submodules: 'recursive'
         persist-credentials: ''
 
+    - name: Get tag version
+      id: tag
+      uses: battila7/get-version-action@v2
+
+    - name: Set version (Release)
+      if: startsWith(github.ref, 'refs/tags/v') == true
+      run: echo '#define MyAppVersion "${{ steps.tag.outputs.version-without-v }}"' >| version.txt
+
+    - name: Set version
+      if: startsWith(github.ref, 'refs/tags/v') != true
+      run: echo '#define MyAppVersion "1.0-${{ github.sha }}"' >| version.txt
+
     - name: Build Windows Installer
       run: .\launcher\windows\build.ps1
 

--- a/launcher/README.md
+++ b/launcher/README.md
@@ -7,6 +7,16 @@ DepthAI Launcher is a small utility that provides installation and updates for D
 DepthAI Launcher includes installation setup for Windows (64bit only).
 Installation carries an embedded Python distribution WinPython, DepthAI Launcher and `depthai` repository.
 
+### Troubleshooting
+
+See the logging file by navigating to `%temp%` directory and searching for `Setup Log` files.
+(Example log path: `C:\Users\[username]\AppData\Local\Temp\Setup Log 2022-01-28 #001.txt`)
+
+Or run the setup by manually providing the log file location:
+```
+.\depthai_setup.exe /LOG=C:\Users\[username]\Desktop\depthai_setup.log
+```
+
 ### Installer
 
 In the following steps, building the Windows installer from source is presented.

--- a/launcher/windows/installer_win64.iss
+++ b/launcher/windows/installer_win64.iss
@@ -1,5 +1,6 @@
 #define MyAppName "DepthAI"
-#define MyAppVersion "1.0"
+; Stores version "MyAppVersion" define
+#include "version.txt"
 #define MyAppPublisher "Luxonis"
 #define MyAppURL "https://www.luxonis.com/"
 #define MyAppExeName "DepthAI.lnk"
@@ -63,6 +64,7 @@ SolidCompression=yes
 WizardStyle=modern
 ; Output build location
 OutputDir=build\Output
+SetupLogging=yes
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"
@@ -101,7 +103,7 @@ Name: "{autoprograms}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"
 Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
 
 [Run]
-Filename: "powershell.exe"; Parameters: "-ExecutionPolicy Bypass -File ""{app}\prerequisite.ps1"""; WorkingDir: {app}; Flags: runhidden
+Filename: "powershell.exe"; Parameters: "-ExecutionPolicy Bypass -File ""{app}\prerequisite.ps1"""; WorkingDir: {app}; Flags: runhidden; StatusMsg: "Installing requirements..."
 Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: shellexec postinstall skipifsilent
 
 ; Creates DepthAI shortcut in installation directory, before installing it as a Desktop Icon
@@ -153,6 +155,8 @@ end;
 {* Handles uninstallation if previous DepthAI version is installed and shortcut creation *}
 procedure CurStepChanged(CurStep: TSetupStep);
 var
+    TmpFileName: string;
+    ExecStdout: AnsiString; 
     ResultCode: Integer;
 begin
   if (CurStep=ssInstall) then
@@ -166,8 +170,14 @@ begin
     ExtractTemporaryFile('create_shortcut.ps1');
     ForceDirectories(ExpandConstant('{app}'));
     FileCopy(ExpandConstant('{tmp}\create_shortcut.ps1'), ExpandConstant('{app}\create_shortcut.ps1'), False);
-    Exec('powershell.exe', ExpandConstant('-ExecutionPolicy Bypass -File "{app}\create_shortcut.ps1"'), ExpandConstant('{app}'), SW_HIDE, ewWaitUntilTerminated, ResultCode);
     
+    TmpFileName := ExpandConstant('{tmp}') + '\create_shortcut_results.txt';
+    Exec('powershell.exe', '-ExecutionPolicy Bypass -File ' + ExpandConstant('"{app}\create_shortcut.ps1"') + ' > "' + TmpFileName + '" 2>&1', ExpandConstant('{app}'), SW_HIDE, ewWaitUntilTerminated, ResultCode);
+    if LoadStringFromFile(TmpFileName, ExecStdout) then begin
+      Log(ExecStdout);
+    end;
+    DeleteFile(TmpFileName);
+
   end;
 end;
 

--- a/launcher/windows/installer_win64.iss
+++ b/launcher/windows/installer_win64.iss
@@ -194,9 +194,6 @@ var
     ResultCode: Integer;
 begin
   Log('Installing prerequisites');
-  ExtractTemporaryFile('create_shortcut.ps1');
-  ForceDirectories(ExpandConstant('{app}'));
-  FileCopy(ExpandConstant('{tmp}\create_shortcut.ps1'), ExpandConstant('{app}\create_shortcut.ps1'), False);
   TmpFileName := ExpandConstant('{tmp}') + '\exec_stdout_stderr_tmp.txt';
   ExecParameter := '/C powershell.exe -ExecutionPolicy Bypass -File "' + ExpandConstant('{app}\prerequisite.ps1') + '" > "' + TmpFileName + '" 2>&1"';
   Log('Calling cmd.exe ' + ExecParameter)

--- a/launcher/windows/version.txt
+++ b/launcher/windows/version.txt
@@ -1,0 +1,1 @@
+#define MyAppVersion "1.0-dev"


### PR DESCRIPTION
- Added versioning to installer that matches depthai demo
- Added logging of powershell scripts that install some requirements during installation process 
- Enabled logging by default and added a troubleshooting section to describe where to find the logs

Note: By default, the version is set to `1.0-dev`. For non-release action builds it gets set to `1.0-[commit hash]` and `[version]` for releases