### PR TITLE
Update `depthai` to latest release 2.15.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ opencv-contrib-python==4.4.0.46 ; platform_machine == "armv6l" or platform_machi
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-depthai-data-local/wheels/
 pyqt5>5,<5.15.6 ; platform_machine != "armv6l" and platform_machine != "armv7l" and platform_machine != "aarch64"
 # --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/
-depthai==2.15.0.0
+depthai==2.15.1.0


### PR DESCRIPTION
Release notes: https://github.com/luxonis/depthai-python/releases/tag/v2.15.1.0

https://github.com/luxonis/depthai/pull/665 will add more features about overheat reporting.