### PR TITLE
depthai 2.17.0.0 - supports new S2/Pro devices, OV9782 as RGB/center camera

### DIFF
--- a/depthai_demo.py
+++ b/depthai_demo.py
@@ -181,8 +181,6 @@ class Demo:
     def setup(self, conf: ConfigManager):
         print("Setting up demo...")
         self._conf = conf
-        self._rgbRes = conf.getRgbResolution()
-        self._monoRes = conf.getMonoResolution()
         if self._conf.args.openvinoVersion:
             self._openvinoVersion = getattr(dai.OpenVINO.Version, 'VERSION_' + self._conf.args.openvinoVersion)
         self._deviceInfo = getDeviceInfo(self._conf.args.deviceId, args.debug)
@@ -225,6 +223,8 @@ class Demo:
             print("USB Connection speed: {}".format(self._device.getUsbSpeed()))
         self._conf.adjustParamsToDevice(self._device)
         self._conf.adjustPreviewToOptions()
+        self._rgbRes = conf.getRgbResolution()
+        self._monoRes = conf.getMonoResolution()
         if self._conf.lowBandwidth:
             self._pm.enableLowBandwidth(poeQuality=self._conf.args.poeQuality)
         self._cap = cv2.VideoCapture(self._conf.args.video) if not self._conf.useCamera else None

--- a/depthai_helpers/config_manager.py
+++ b/depthai_helpers/config_manager.py
@@ -109,6 +109,10 @@ class ConfigManager:
             return dai.ColorCameraProperties.SensorResolution.THE_4_K
         elif self.args.rgbResolution == 3040:
             return dai.ColorCameraProperties.SensorResolution.THE_12_MP
+        elif self.args.rgbResolution == 720:
+            return dai.ColorCameraProperties.SensorResolution.THE_720_P
+        elif self.args.rgbResolution == 800:
+            return dai.ColorCameraProperties.SensorResolution.THE_800_P
         else:
             return dai.ColorCameraProperties.SensorResolution.THE_1080_P
 
@@ -164,6 +168,20 @@ class ConfigManager:
         deviceInfo = device.getDeviceInfo()
         cams = device.getConnectedCameras()
         depthEnabled = dai.CameraBoardSocket.LEFT in cams and dai.CameraBoardSocket.RIGHT in cams
+
+        sensorNames = device.getCameraSensorNames()
+        if dai.CameraBoardSocket.RGB in cams:
+            name = sensorNames[dai.CameraBoardSocket.RGB]
+            if name == 'OV9782':
+                if self.args.rgbResolution not in [720, 800]:
+                    self.args.rgbResolution = 800
+                    cliPrint(f'{name} requires 720 or 800 resolution, defaulting to {self.args.rgbResolution}', 
+                             PrintColors.RED)
+            else:
+                if self.args.rgbResolution in [720, 800]:
+                    self.args.rgbResolution = 1080
+                    cliPrint(f'{name} doesn\'t support 720 / 800 resolutions, defaulting to {self.args.rgbResolution}', 
+                             PrintColors.RED)
 
         if not depthEnabled:
             if not self.args.disableDepth:

--- a/depthai_sdk/src/depthai_sdk/managers/arg_manager.py
+++ b/depthai_sdk/src/depthai_sdk/managers/arg_manager.py
@@ -33,8 +33,8 @@ class ArgsManager:
         parser.add_argument('-sh', '--shaves', type=int, help="Number of MyriadX SHAVEs to use for neural network blob compilation")
         parser.add_argument('-cnnsize', '--cnnInputSize', default=None, type=str,
                             help="Neural network input dimensions, in \"WxH\" format, e.g. \"544x320\"")
-        parser.add_argument("-rgbr", "--rgbResolution", default=1080, type=int, choices=[1080, 2160, 3040],
-                            help="RGB cam res height: (1920x)1080, (3840x)2160 or (4056x)3040. Default: %(default)s")
+        parser.add_argument("-rgbr", "--rgbResolution", default=1080, type=int, choices=[1080, 2160, 3040, 720, 800],
+                            help="RGB cam res height: (1920x)1080, (3840x)2160, (4056x)3040, (1280x)720, (1280x)800. Default: %(default)s")
         parser.add_argument("-rgbf", "--rgbFps", default=30.0, type=float,
                             help="RGB cam fps: max 118.0 for H:1080, max 42.0 for H:2160. Default: %(default)s")
         parser.add_argument("-dct", "--disparityConfidenceThreshold", default=245, type=self._checkRange(0, 255),

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ opencv-contrib-python==4.4.0.46 ; platform_machine == "armv6l" or platform_machi
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-depthai-data-local/wheels/
 pyqt5>5,<5.15.6 ; platform_machine != "armv6l" and platform_machine != "armv7l" and platform_machine != "aarch64"
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/
-depthai==2.16.0.0.dev+ad18199a840e792346d2f01723c6cd4e0817d371
+depthai==2.17.0.0


### PR DESCRIPTION
Also adding the options `720` and `800` to `-rgbr`/`--rgbResolution`, and defaulting to `800` (instead of `1080`) for OV9782.