### PR TITLE
depthai_demo: add `-tun`/`--cameraTuning` option

### DIFF
--- a/depthai_demo.py
+++ b/depthai_demo.py
@@ -193,6 +193,9 @@ class Demo:
         if self._conf.args.xlinkChunkSize is not None:
             self._pm.setXlinkChunkSize(self._conf.args.xlinkChunkSize)
 
+        if self._conf.args.cameraTuning:
+            self._pm.setCameraTuningBlob(self._conf.args.cameraTuning)
+
         self._nnManager = None
         if self._conf.useNN:
             self._blobManager = BlobManager(

--- a/depthai_sdk/src/depthai_sdk/managers/arg_manager.py
+++ b/depthai_sdk/src/depthai_sdk/managers/arg_manager.py
@@ -114,6 +114,7 @@ class ArgsManager:
         parser.add_argument('--noRgbDepthAlign', action="store_true", help="Disable RGB-Depth align (depth frame will be aligned with the RGB frame)")
         parser.add_argument('--debug', action="store_true", help="Enables debug mode. Capability to connect to already BOOTED devices and also implicitly disables version check")
         parser.add_argument("-app","--app", type=str, choices=["uvc", "record"], help="Specify which app to run instead of the demo")
+        parser.add_argument('-tun', '--cameraTuning', type=Path, help="Path to camera tuning blob to use, overriding the built-in tuning")
         
         if parse:
             return parser.parse_args()

--- a/depthai_sdk/src/depthai_sdk/managers/pipeline_manager.py
+++ b/depthai_sdk/src/depthai_sdk/managers/pipeline_manager.py
@@ -589,6 +589,9 @@ class PipelineManager:
     def setXlinkChunkSize(self, chunkSize):
         self.pipeline.setXLinkChunkSize(chunkSize)
 
+    def setCameraTuningBlob(self, path):
+        self.pipeline.setCameraTuningBlobPath(path)
+
     def _getMedianFilter(self, size: int) -> dai.MedianFilter:
         if size == 3:
             return dai.MedianFilter.KERNEL_3x3


### PR DESCRIPTION
Add a command line option to override the camera tuning blob to use, for example as:
`-tun path/to...../tuning_color_ov9782_wide_fov.bin`

More details about the camera tuning: https://docs.luxonis.com/projects/api/en/latest/tutorials/camera_tuning/

___
Use case: new tuning blob added at the link below, that fixes OV9782 (color global shutter) color cast issues at very low exposure times (example: bright daylight).
https://artifacts.luxonis.com/artifactory/luxonis-depthai-data-local/misc/tuning_color_ov9782_wide_fov.bin
(note: this tuning currently doesn't support mono cameras, so they have to be disabled, and only the color camera enabled)

Can be tested as (extra options mainly for disabling mono cameras):
- initial:
```
python3 depthai_demo.py -s color -gt cv -dd -dnn
```
- with the new tuning:
```
python3 depthai_demo.py -s color -gt cv -dd -dnn -tun ~/Downloads/tuning_color_ov9782_wide_fov.bin
```