### PR TITLE
Catch if missing requirements

### DIFF
--- a/depthai_demo.py
+++ b/depthai_demo.py
@@ -21,7 +21,16 @@ if platform.machine() == 'aarch64':  # Jetson
 
 sys.path.append(str(Path(__file__).parent.absolute()))
 sys.path.append(str((Path(__file__).parent / "depthai_sdk" / "src").absolute()))
-from depthai_sdk.managers import ArgsManager, getMonoResolution, getRgbResolution
+
+try:
+    import cv2
+    import depthai as dai
+    import numpy as np
+    from depthai_sdk.managers import ArgsManager, getMonoResolution, getRgbResolution
+except Exception as ex:
+    print("Third party libraries failed to import: {}".format(ex))
+    print("Run \"python3 install_requirements.py\" to install dependencies or visit our installation page for more details - https://docs.luxonis.com/projects/api/en/latest/install/")
+    sys.exit(42)
 
 app = ArgsManager.parseApp()
 
@@ -36,14 +45,7 @@ if __name__ == "__main__":
         except KeyboardInterrupt:
             sys.exit(0)
 
-try:
-    import cv2
-    import depthai as dai
-    import numpy as np
-except Exception as ex:
-    print("Third party libraries failed to import: {}".format(ex))
-    print("Run \"python3 install_requirements.py\" to install dependencies or visit our installation page for more details - https://docs.luxonis.com/projects/api/en/latest/install/")
-    sys.exit(42)
+
 
 from log_system_information import make_sys_report
 from depthai_helpers.supervisor import Supervisor


### PR DESCRIPTION
## Catch if there are missing requirements.

Issue found while testing PR #744.

- On my machine (running Windows 11) the installer doesn't install the requirements.txt since at least version 2.0.0.

- It was always taken care of on the first run, where this [error handling](https://github.com/luxonis/depthai/blob/92c66ab3e868915623329e703f154e6afd0b35f0/launcher/launcher.py#L268) would take care of the dependencies.

- This got broken with this https://github.com/luxonis/depthai/blob/e6d7feaa51e521b7b8a697bc2ec86caf5e1cb3b6/depthai_demo.py#L24 as imports were introduced without "try and except" guards.

This PR should solve the issue.
CC: @Erol444 @themarpe 

