### PR TITLE
Update depthai version to 2.17.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ opencv-contrib-python==4.4.0.46 ; platform_machine == "armv6l" or platform_machi
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-depthai-data-local/wheels/
 pyqt5>5,<5.15.6 ; platform_machine != "armv6l" and platform_machine != "armv7l" and platform_machine != "aarch64"
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/
-depthai==2.17.1.0
+depthai==2.17.3.0


### PR DESCRIPTION
To support latest boards.
Users were reporting that the board received doesn't work, because demo is still at 2.17.1.0.
Will make a release too.