### PR TITLE
Always show disparity

### DIFF
--- a/depthai_helpers/config_manager.py
+++ b/depthai_helpers/config_manager.py
@@ -141,10 +141,7 @@ class ConfigManager:
 
         self.args.show.append(Previews.color.name)
         if self.useDepth:
-            if self.lowBandwidth:
-                self.args.show.append(Previews.disparityColor.name)
-            else:
-                self.args.show.append(Previews.depth.name)
+            self.args.show.append(Previews.disparityColor.name)
 
         if self.args.guiType == "qt":
             if self.useNN:


### PR DESCRIPTION
PR related to: https://luxonis.youtrack.cloud/issue/C-383
Issue was not with usb used, but rather the bandwidth. Fixed so now desparity is always used (and not depth) regardless of bandwidth.