### PR TITLE
Minor Fixes For Calibrate Script

### DIFF
--- a/calibrate.py
+++ b/calibrate.py
@@ -337,7 +337,10 @@ class Main:
         timer = self.args.captureDelay
         prev_time = None
         curr_time = None
-        self.display_name = "left + right + rgb"
+        if not self.args.disableRgb:
+            self.display_name = "left + right + rgb"
+        else:
+            self.display_name = "left + right"
         last_frame_time = time.time()
         # with self.get_pipeline() as pipeline:
         while not finished:
@@ -500,7 +503,6 @@ class Main:
                 combine_img = np.hstack((frame_list[0], frame_list[1], frame_list[2]))
             else:
                 combine_img = np.vstack((frame_list[0], frame_list[1]))
-                self.display_name = "left + right"
 
             if start_timer == True:
                 curr_time = time.time()
@@ -510,7 +512,7 @@ class Main:
                 if timer <= 0 and start_timer == True:
                     start_timer = False
                     capturing = True
-                    print('Statrt capturing...')
+                    print('Start capturing...')
 
                 image_shape = combine_img.shape
                 cv2.putText(combine_img, str(timer),


### PR DESCRIPTION
- Set display_name at beginning of capture_images rather than defaulting to rgb name and changing it when combining left & right only
- Fix typo in "Start capturing..." text