### PR TITLE
Oak sync

### DIFF
--- a/depthai_sdk/examples/emotion-recognition.py
+++ b/depthai_sdk/examples/emotion-recognition.py
@@ -25,6 +25,6 @@ with OakCamera() as oak:
 
     # Visualize detections on the frame. Also display FPS on the frame. Don't show the frame but send the packet
     # to the callback function (where it will be displayed)
-    oak.visualize([emotion_nn, emotion_nn.out_passthrough], fps=True, callback=cb)
+    oak.visualize([emotion_nn, emotion_nn.out.passthrough])
     # oak.show_graph() # Show pipeline graph, no need for now
     oak.start(blocking=True) # This call will block until the app is stopped (by pressing 'Q' button)

--- a/depthai_sdk/examples/encode.py
+++ b/depthai_sdk/examples/encode.py
@@ -10,6 +10,6 @@ with OakCamera() as oak:
 
     # Sync & save all (encoded) streams
     oak.record([color.out.encoded, left.out.encoded, right.out.encoded], './', RecordType.VIDEO)
-    oak.visualize([nn], scale=2/3, fps=True)
+    oak.visualize([nn])
 
     oak.start(blocking=True)

--- a/depthai_sdk/examples/sync_multiple_outputs.py
+++ b/depthai_sdk/examples/sync_multiple_outputs.py
@@ -9,9 +9,9 @@ with OakCamera() as oak:
     # oak.visualize([nn.out.main, nn.out.passthrough])
     # oak.visualize(nn.out.spatials, scale=1 / 2)
     def cb(msgs: Dict):
-        print(msgs)
+        print('synced!', msgs)
 
-    oak.sync([color.out.encoded, nn.out.main, nn2.out.main], cb)
+    oak.sync([color.out.encoded, nn.out.passthrough, nn.out.main, nn2.out.main], cb)
     # oak.show_graph()
 
     oak.start(blocking=True)

--- a/depthai_sdk/examples/sync_multiple_outputs.py
+++ b/depthai_sdk/examples/sync_multiple_outputs.py
@@ -5,12 +5,13 @@ from depthai_sdk import OakCamera
 with OakCamera() as oak:
     color = oak.create_camera('color', encode='h264')
     nn = oak.create_nn('mobilenet-ssd', color)
+    nn2 = oak.create_nn('face-detection-retail-0004', color)
     # oak.visualize([nn.out.main, nn.out.passthrough])
     # oak.visualize(nn.out.spatials, scale=1 / 2)
     def cb(msgs: Dict):
         print(msgs)
 
-    oak.sync([color.out.encoded, nn.out.passthrough], cb)
+    oak.sync([color.out.encoded, nn.out.main, nn2.out.main], cb)
     # oak.show_graph()
 
     oak.start(blocking=True)

--- a/depthai_sdk/examples/sync_multiple_outputs.py
+++ b/depthai_sdk/examples/sync_multiple_outputs.py
@@ -1,0 +1,16 @@
+from typing import Dict
+
+from depthai_sdk import OakCamera
+
+with OakCamera() as oak:
+    color = oak.create_camera('color', encode='h264')
+    nn = oak.create_nn('mobilenet-ssd', color)
+    # oak.visualize([nn.out.main, nn.out.passthrough])
+    # oak.visualize(nn.out.spatials, scale=1 / 2)
+    def cb(msgs: Dict):
+        print(msgs)
+
+    oak.sync([color.out.encoded, nn.out.passthrough], cb)
+    # oak.show_graph()
+
+    oak.start(blocking=True)

--- a/depthai_sdk/src/depthai_sdk/classes/output_config.py
+++ b/depthai_sdk/src/depthai_sdk/classes/output_config.py
@@ -98,10 +98,8 @@ class SyncConfig(BaseConfig, XoutSeqSync):
         XoutSeqSync.__init__(self, []) # We don't yet have streams, we will set it up later
         self.outputs = outputs
         self.cb = callback
-        print(self.cb)
 
     def package(self, msgs: Dict):
-        print(self.cb)
         self.cb(msgs)
     def visualize(self, packet) -> None:
         pass # No need.

--- a/depthai_sdk/src/depthai_sdk/classes/output_config.py
+++ b/depthai_sdk/src/depthai_sdk/classes/output_config.py
@@ -90,3 +90,29 @@ class RecordConfig(BaseConfig):
         self.rec.start(device, xouts)
 
         return self.rec
+
+class SyncConfig(BaseConfig, XoutSeqSync):
+    outputs: List[Callable]
+    cb: Callable
+    def __init__(self, outputs: List[Callable], callback: Callable):
+        XoutSeqSync.__init__(self, []) # We don't yet have streams, we will set it up later
+        self.outputs = outputs
+        self.cb = callback
+        print(self.cb)
+
+    def package(self, msgs: Dict):
+        print(self.cb)
+        self.cb(msgs)
+    def visualize(self, packet) -> None:
+        pass # No need.
+    def setup(self, pipeline: dai.Pipeline, device: dai.Device, _) -> XoutBase:
+        self._streams = []
+        for output in self.outputs:
+            xoutbase: XoutBase = output(pipeline, device)
+            xoutbase.setup_base(None)
+            self._streams.extend(xoutbase._streams)
+
+        super().setup_base(None)
+        return self
+
+

--- a/depthai_sdk/src/depthai_sdk/classes/output_config.py
+++ b/depthai_sdk/src/depthai_sdk/classes/output_config.py
@@ -109,10 +109,10 @@ class SyncConfig(BaseConfig, SequenceNumSync):
         self.packets = dict()
 
     def new_packet(self, packet: FramePacket):
-        print('new packet', packet)
+        # print('new packet', packet, packet.name, 'seq num',packet.imgFrame.getSequenceNum())
         synced = self.sync(
             packet.imgFrame.getSequenceNum(),
-            packet.,
+            packet.name,
             packet
         )
         if synced:

--- a/depthai_sdk/src/depthai_sdk/oak_camera.py
+++ b/depthai_sdk/src/depthai_sdk/oak_camera.py
@@ -368,6 +368,17 @@ class OakCamera:
 
         return self._pipeline
 
+    def sync(self, outputs: Union[Callable, List[Callable]], callback: Callable):
+        """
+        Synchronize multiple components outputs forward them to the callback.
+        Args:
+            outputs: Component output(s)
+            callback: Where to send synced streams
+        """
+        if isinstance(outputs, Callable):
+            outputs = [outputs]  # to list
+        self._out_templates.append(SyncConfig(outputs, callback))
+
     def record(self, outputs: Union[Callable, List[Callable]], path: str, type: RecordType = RecordType.VIDEO):
         """
         Record component outputs. This handles syncing multiple streams (eg. left, right, color, depth) and saving

--- a/depthai_sdk/src/depthai_sdk/oak_camera.py
+++ b/depthai_sdk/src/depthai_sdk/oak_camera.py
@@ -6,10 +6,11 @@ from typing import Dict, Any, Optional, List, Union, Callable, Tuple
 
 import cv2
 import depthai as dai
+from depthai_sdk.oak_outputs.xout_base import XoutBase
 
 from depthai_sdk.visualize import Visualizer
 from depthai_sdk.args_parser import ArgsParser
-from depthai_sdk.classes.output_config import BaseConfig, RecordConfig, OutputConfig
+from depthai_sdk.classes.output_config import BaseConfig, RecordConfig, OutputConfig, SyncConfig
 from depthai_sdk.components.camera_component import CameraComponent
 from depthai_sdk.components.component import Component
 from depthai_sdk.components.imu_component import IMUComponent
@@ -353,8 +354,8 @@ class OakCamera:
 
         names = []
         for out in self._out_templates:
-            xoutbase = out.setup(self._pipeline, self._oak.device, names)
-            self._oak.oak_out_streams.append(xoutbase)
+            xouts = out.setup(self._pipeline, self._oak.device, names)
+            self._oak.oak_out_streams.extend(xouts)
 
         # User-defined arguments
         if self._args:
@@ -368,16 +369,18 @@ class OakCamera:
 
         return self._pipeline
 
-    def sync(self, outputs: Union[Callable, List[Callable]], callback: Callable):
+    def sync(self, outputs: Union[Callable, List[Callable]], callback: Callable, visualize=False):
         """
         Synchronize multiple components outputs forward them to the callback.
         Args:
             outputs: Component output(s)
             callback: Where to send synced streams
+            visualize: Whether to draw on the frames (like with visualize())
         """
+        visualizer = Visualizer() if visualize else None
         if isinstance(outputs, Callable):
             outputs = [outputs]  # to list
-        self._out_templates.append(SyncConfig(outputs, callback))
+        self._out_templates.append(SyncConfig(outputs, callback, visualizer))
 
     def record(self, outputs: Union[Callable, List[Callable]], path: str, type: RecordType = RecordType.VIDEO):
         """

--- a/depthai_sdk/src/depthai_sdk/oak_camera.py
+++ b/depthai_sdk/src/depthai_sdk/oak_camera.py
@@ -310,7 +310,10 @@ class OakCamera:
             if self.replay._stop:
                 return False
 
-        return True  # TODO: check whether OAK is connected
+        if self.device.isClosed():
+            return False
+
+        return True
 
     def build(self) -> dai.Pipeline:
         """

--- a/depthai_sdk/src/depthai_sdk/oak_device.py
+++ b/depthai_sdk/src/depthai_sdk/oak_device.py
@@ -33,11 +33,6 @@ class OakDevice:
         for sync in self.oak_out_streams:
             sync.newMsg(name, msg)
 
-        # if name not in self.fpsHandlers:
-        #     self.fpsHandlers[name] = FPS()
-        # self.fpsHandlers[name].next_iter()
-        # print(name,' fps', self.fpsHandlers[name].fps())
-
     def checkSync(self):
         """
         Checks whether there are new synced messages, non-blocking.

--- a/depthai_sdk/src/depthai_sdk/oak_outputs/syncing.py
+++ b/depthai_sdk/src/depthai_sdk/oak_outputs/syncing.py
@@ -1,0 +1,49 @@
+from typing import Dict, List, Any, Optional
+
+
+class SequenceNumSync:
+    msgs: Dict[str, Dict[str, Any]]  # List of messages.
+    """
+        msgs = {seqNum: {name: message}}
+        Example:
+
+        msgs = {
+            '1': {
+                'rgb': dai.Frame(),
+                'dets': dai.ImgDetections(),
+            ],
+            '2': {
+                'rgb': dai.Frame(),
+                'dets': dai.ImgDetections(),
+            }
+        }
+        """
+    streamNum: int
+
+    def __init__(self, streamNum: int):
+        self.msgs = dict()
+        self.streamNum = streamNum
+
+
+    def sync(self, seqNum: int, name: str, msg) -> Optional[Dict]:
+        seqNum = str(seqNum)
+        if seqNum not in self.msgs: self.msgs[seqNum] = dict()
+
+        self.msgs[seqNum][name] = (msg)
+
+        if self.streamNum == len(self.msgs[seqNum]):
+            # We have sequence num synced frames!
+            ret = self.msgs[seqNum]
+
+            # Remove previous msgs
+            newMsgs = {}
+            for name, msg in self.msgs.items():
+                if int(name) > int(seqNum):
+                    newMsgs[name] = msg
+            self.msgs = newMsgs
+
+            return ret
+        return None
+
+
+

--- a/depthai_sdk/src/depthai_sdk/oak_outputs/xout.py
+++ b/depthai_sdk/src/depthai_sdk/oak_outputs/xout.py
@@ -287,7 +287,7 @@ class XoutDisparity(XoutFrames, XoutClickable):
                 self.queue.get()  # Get one, so queue isn't full
 
             packet = DepthPacket(
-                self.frames.name,
+                self.get_packet_name(),
                 self.msgs[seq][self.frames.name],
                 self.msgs[seq][self.mono_frames.name],
             )
@@ -392,7 +392,7 @@ class XoutDepth(XoutFrames, XoutClickable):
                 self.queue.get()  # Get one, so queue isn't full
 
             packet = DepthPacket(
-                self.frames.name,
+                self.get_packet_name(),
                 self.msgs[seq][self.frames.name],
                 self.msgs[seq][self.mono_frames.name],
             )
@@ -457,7 +457,7 @@ class XoutSpatialBbMappings(XoutFrames):
                 self.queue.get()  # Get one, so queue isn't full
 
             packet = SpatialBbMappingPacket(
-                self.frames.name,
+                self.get_packet_name(),
                 self.depth_msg,
                 self.config_msg
             )
@@ -504,11 +504,11 @@ class XoutNnResults(XoutSeqSync, XoutFrames):
 
     def __init__(self, det_nn, frames: StreamXout, nn_results: StreamXout):
         self.nn_results = nn_results
+        self.det_nn = det_nn
         # Multiple inheritance init
         XoutFrames.__init__(self, frames)
         XoutSeqSync.__init__(self, [frames, nn_results])
         # Save StreamXout before initializing super()!
-        self.det_nn = det_nn
 
         # TODO: add support for colors, generate new colors for each label that doesn't have colors
         if det_nn._labels:
@@ -553,7 +553,7 @@ class XoutNnResults(XoutSeqSync, XoutFrames):
         if self.queue.full():
             self.queue.get()  # Get one, so queue isn't full
         packet = DetectionPacket(
-            self.frames.name,
+            self.get_packet_name(),
             msgs[self.frames.name],
             msgs[self.nn_results.name],
         )
@@ -613,7 +613,7 @@ class XoutTracker(XoutNnResults):
         if self.queue.full():
             self.queue.get()  # Get one, so queue isn't full
         packet = TrackerPacket(
-            self.frames.name,
+            self.get_packet_name(),
             msgs[self.frames.name],
             msgs[self.nn_results.name],
         )
@@ -718,7 +718,7 @@ class XoutTwoStage(XoutNnResults):
                 self.queue.get()  # Get one, so queue isn't full
 
             packet = TwoStagePacket(
-                self.frames.name,
+                self.get_packet_name(),
                 self.msgs[seq][self.frames.name],
                 self.msgs[seq][self.nn_results.name],
                 self.msgs[seq][self.second_nn.name],

--- a/depthai_sdk/src/depthai_sdk/oak_outputs/xout_base.py
+++ b/depthai_sdk/src/depthai_sdk/oak_outputs/xout_base.py
@@ -35,6 +35,13 @@ class XoutBase(ABC):
     def __init__(self) -> None:
         self._streams = [xout.name for xout in self.xstreams()]
 
+
+    _packet_name: str = None
+    def get_packet_name(self) -> str:
+        if self._packet_name is None:
+            self._packet_name = ";".join([xout.name for xout in self.xstreams()])
+        return self._packet_name
+
     @abstractmethod
     def xstreams(self) -> List[StreamXout]:
         raise NotImplementedError()

--- a/depthai_sdk/src/depthai_sdk/record.py
+++ b/depthai_sdk/src/depthai_sdk/record.py
@@ -48,6 +48,7 @@ class Record(XoutSeqSync):
 
     def package(self, msgs: Dict):
         # Here we get sequence-num synced messages:)
+        print('package new frames record', msgs)
         mapped = dict()
         for name, msg in msgs.items():
             if name in self.name_mapping:  # Map to friendly name
@@ -76,6 +77,7 @@ class Record(XoutSeqSync):
         start recording threads, and initialize all queues.
         """
         self._streams = [out.frames.name for out in xouts]  # required by XoutSeqSync
+        self.streamNum = len(self._streams)
 
         self.name_mapping = dict()
         for xout in xouts:

--- a/depthai_sdk/src/depthai_sdk/visualize/objects.py
+++ b/depthai_sdk/src/depthai_sdk/visualize/objects.py
@@ -267,7 +267,7 @@ class VisDetections(GenericObject):
         return parent
 
     def register_detection(self,
-                           bbox: Union[np.ndarray[Tuple[int, int, int, int]]],
+                           bbox: Union[Tuple[int, int, int, int]],
                            label: str,
                            color: Tuple[int, int, int]) -> None:
         """


### PR DESCRIPTION
Logs from `sync_multiple_outputs.py`:
```
{'1_bitstream': <depthai.ImgFrame object at 0x000001766C3F91F0>, '2_passthrough': <depthai.ImgFrame object at 0x000001766C40C2F0>, '2_out': <depthai.ImgDetections object at 0x000001766C40C070>}

{'1_bitstream': <depthai.ImgFrame object at 0x000001766C40BFB0>, '2_passthrough': <depthai.ImgFrame object at 0x000001766C40C070>, '2_out': <depthai.ImgDetections object at 0x000001766C40C2F0>}

{'1_bitstream': <depthai.ImgFrame object at 0x000001766C3F91F0>, '2_out': <depthai.ImgDetections object at 0x000001766C40C2F0>, '2_passthrough': <depthai.ImgFrame object at 0x000001766C40C070>}
```