### PR TITLE
Fix typo in annotation that caused error on Python <= 3.7 and fix mat…

### DIFF
--- a/depthai_sdk/requirements.txt
+++ b/depthai_sdk/requirements.txt
@@ -11,4 +11,5 @@ distinctipy
 xmltodict
 PySide2
 Qt.py>=1.3.0
-matplotlib==3.6.1
+matplotlib==3.5.3; python_version <= "3.7"
+matplotlib==3.6.1; python_version > "3.7"

--- a/depthai_sdk/src/depthai_sdk/visualize/objects.py
+++ b/depthai_sdk/src/depthai_sdk/visualize/objects.py
@@ -267,7 +267,7 @@ class VisDetections(GenericObject):
         return parent
 
     def register_detection(self,
-                           bbox: Union[np.ndarray[Tuple[int, int, int, int]]],
+                           bbox: Union[np.ndarray, Tuple[int, int, int, int]],
                            label: str,
                            color: Tuple[int, int, int]) -> None:
         """


### PR DESCRIPTION
- Fix `TypeError: Type subscription requires python >= 3.9`
- Fix error installing matplotlib from requirements.txt with Python 3.7