### PR TITLE
Fix stereo recording

### DIFF
--- a/depthai_sdk/docs/source/features/ai_models.rst
+++ b/depthai_sdk/docs/source/features/ai_models.rst
@@ -12,7 +12,7 @@ Through the :ref:`NNComponent`, DepthAI SDK abstracts:
 SDK supported models
 ####################
 
-With :ref:`NN Component` you can **easily try out a variety of different pre-trained models** by simply changing the model name:
+With :ref:`NNComponent` you can **easily try out a variety of different pre-trained models** by simply changing the model name:
 
 .. code-block:: diff
 

--- a/depthai_sdk/docs/source/features/components.rst
+++ b/depthai_sdk/docs/source/features/components.rst
@@ -1,8 +1,8 @@
 Components
 ==========
 
-SDK components abstract `DepthAI API nodes <https://docs.luxonis.com/projects/api/en/latest/components/nodes/>`__; their initialization, configuration,
-and linking. This improves ease of use when developing OAK aplications.
+Components are part of the :ref:`OakCamera` class and abstract `DepthAI API nodes <https://docs.luxonis.com/projects/api/en/latest/components/nodes/>`__;
+their initialization, configuration, and linking. This improves ease of use when developing OAK aplications.
 
 **Available components**
 

--- a/depthai_sdk/examples/StereoComponent/stereo_record.py
+++ b/depthai_sdk/examples/StereoComponent/stereo_record.py
@@ -1,0 +1,32 @@
+import cv2
+import depthai
+
+from depthai_sdk import OakCamera
+from depthai_sdk.visualize.configs import StereoColor
+
+
+def callback(msgs, visualizer):
+    for name, packet in msgs.items():
+        cv2.imshow(packet.name, packet.frame)
+
+
+with OakCamera(usbSpeed=depthai.UsbSpeed.HIGH) as oak:
+    color = oak.create_camera('color', resolution='1080p', fps=30)
+    stereo = oak.create_stereo('400p', fps=30)
+
+    stereo.configure_postprocessing(
+        colorize=StereoColor.RGB,
+        colormap=cv2.COLORMAP_JET,
+        wls_filter=True,
+        wls_lambda=8000,
+        wls_sigma=1.5
+    )
+
+    # Record RGB and disparity to records folder
+    # Record doesn't work with visualize so the config is ignored
+    oak.record([color.out.main, stereo.out.disparity], 'records')
+
+    # Record depth only
+    # oak.visualize(stereo.out.depth, record='depth.avi')
+
+    oak.start(blocking=True)

--- a/depthai_sdk/examples/StereoComponent/stereo_record.py
+++ b/depthai_sdk/examples/StereoComponent/stereo_record.py
@@ -11,8 +11,8 @@ def callback(msgs, visualizer):
 
 
 with OakCamera(usbSpeed=depthai.UsbSpeed.HIGH) as oak:
-    color = oak.create_camera('color', resolution='1080p', fps=30)
-    stereo = oak.create_stereo('400p', fps=30)
+    color = oak.create_camera('color', resolution='1080p', fps=5)
+    stereo = oak.create_stereo('400p', fps=5)
 
     stereo.configure_postprocessing(
         colorize=StereoColor.RGB,

--- a/depthai_sdk/examples/recording/encoder_preview.py
+++ b/depthai_sdk/examples/recording/encoder_preview.py
@@ -1,6 +1,5 @@
 from depthai_sdk import OakCamera, FramePacket
 from depthai_sdk.recorders.video_writers.av_writer import  AvWriter
-
 from pathlib import Path
 
 rec = AvWriter(Path('./'), 'color', 'mjpeg', fps=30)

--- a/depthai_sdk/examples/replay/youtube-download.py
+++ b/depthai_sdk/examples/replay/youtube-download.py
@@ -2,7 +2,7 @@ from depthai_sdk import OakCamera
 
 with OakCamera(replay='https://www.youtube.com/watch?v=Y1jTEyb3wiI') as oak:
     color = oak.create_camera('color')
-    nn = oak.create_nn('vehicle-detection-0202', color, tracker=True)
+    nn = oak.create_nn('vehicle-detection-0202', color)
     oak.visualize([nn.out.passthrough], fps=True)
-    oak.visualize([nn.out.tracker], scale=2 / 3, fps=True)
+    oak.visualize(nn, scale=2 / 3, fps=True)
     oak.start(blocking=True)

--- a/depthai_sdk/src/depthai_sdk/classes/output_config.py
+++ b/depthai_sdk/src/depthai_sdk/classes/output_config.py
@@ -1,15 +1,14 @@
 from abc import abstractmethod
-from typing import Optional, Callable, Union, Tuple, List
+from typing import Optional, Callable, List
 
 import depthai as dai
-from depthai_sdk import FramePacket
 
-from depthai_sdk.visualize import Visualizer
+from depthai_sdk import FramePacket
+from depthai_sdk.oak_outputs.syncing import SequenceNumSync
 from depthai_sdk.oak_outputs.xout import XoutFrames
 from depthai_sdk.oak_outputs.xout_base import XoutBase
 from depthai_sdk.record import Record
-
-from depthai_sdk.oak_outputs.syncing import SequenceNumSync
+from depthai_sdk.visualize import Visualizer
 
 
 # class VisualizeConfig:
@@ -109,7 +108,7 @@ class SyncConfig(BaseConfig, SequenceNumSync):
 
         self.packets = dict()
 
-    def new_packet(self, packet: FramePacket):
+    def new_packet(self, packet: FramePacket, _=None):
         # print('new packet', packet, packet.name, 'seq num',packet.imgFrame.getSequenceNum())
         synced = self.sync(
             packet.imgFrame.getSequenceNum(),
@@ -117,7 +116,7 @@ class SyncConfig(BaseConfig, SequenceNumSync):
             packet
         )
         if synced:
-            self.cb(synced)
+            self.cb(synced) if self.visualizer is None else self.cb(synced, self.visualizer)
 
     def setup(self, pipeline: dai.Pipeline, device: dai.Device, _) -> List[XoutBase]:
         xouts = []

--- a/depthai_sdk/src/depthai_sdk/components/nn_component.py
+++ b/depthai_sdk/src/depthai_sdk/components/nn_component.py
@@ -4,13 +4,13 @@ from typing import Callable, Union, List, Dict
 
 import blobconverter
 
+from depthai_sdk.classes.nn_config import Config
 from depthai_sdk.components.camera_component import CameraComponent
 from depthai_sdk.components.component import Component
 from depthai_sdk.components.multi_stage_nn import MultiStageNN, MultiStageConfig
 from depthai_sdk.components.nn_helper import *
 from depthai_sdk.components.parser import *
 from depthai_sdk.components.stereo_component import StereoComponent
-from depthai_sdk.classes.nn_config import Config
 from depthai_sdk.oak_outputs.xout import XoutNnResults, XoutTwoStage, XoutSpatialBbMappings, XoutFrames, XoutTracker
 from depthai_sdk.oak_outputs.xout_base import StreamXout, XoutBase
 from depthai_sdk.replay import Replay
@@ -193,8 +193,8 @@ class NNComponent(Component):
         else:  # SDK supported model
             models = getSupportedModels(printModels=False)
             if str(model) not in models:
-                raise ValueError(f"Specified model '{str(model)}' is not supported by DepthAI SDK. \
-                    Check SDK documentation page to see which models are supported.")
+                raise ValueError(f"Specified model '{str(model)}' is not supported by DepthAI SDK.\n"
+                                 "Check SDK documentation page to see which models are supported.")
 
             model = models[str(model)] / 'config.json'
             self._parse_config(model)

--- a/depthai_sdk/src/depthai_sdk/oak_outputs/syncing.py
+++ b/depthai_sdk/src/depthai_sdk/oak_outputs/syncing.py
@@ -24,7 +24,6 @@ class SequenceNumSync:
         self.msgs = dict()
         self.streamNum = streamNum
 
-
     def sync(self, seqNum: int, name: str, msg) -> Optional[Dict]:
         seqNum = str(seqNum)
         if seqNum not in self.msgs: self.msgs[seqNum] = dict()
@@ -44,6 +43,3 @@ class SequenceNumSync:
 
             return ret
         return None
-
-
-

--- a/depthai_sdk/src/depthai_sdk/oak_outputs/xout.py
+++ b/depthai_sdk/src/depthai_sdk/oak_outputs/xout.py
@@ -104,10 +104,12 @@ class XoutFrames(XoutBase):
                 self._frames_buffer.append(packet.frame)
             else:
                 h, w = self._visualizer.frame_shape[:2]
+                c = self._visualizer.frame_shape[2] if len(self._visualizer.frame_shape) == 3 else 1
                 self._video_writer = cv2.VideoWriter(str(self._recording_path),
                                                      self._fourcc_codec_code,
                                                      self._fps.fps(),
-                                                     (w, h)
+                                                     (w, h),
+                                                     isColor=int(c > 1)
                                                      )
                 # Write all buffered frames
                 for frame in self._frames_buffer:

--- a/depthai_sdk/src/depthai_sdk/recorders/abstract_recorder.py
+++ b/depthai_sdk/src/depthai_sdk/recorders/abstract_recorder.py
@@ -3,7 +3,7 @@ from enum import IntEnum
 
 import depthai as dai
 
-from depthai_sdk.oak_outputs.xout import XoutFrames, XoutH26x, XoutMjpeg, XoutDepth
+from depthai_sdk.oak_outputs.xout import XoutFrames, XoutH26x, XoutMjpeg, XoutDepth, XoutDisparity
 from depthai_sdk.oak_outputs.xout_base import XoutBase
 
 
@@ -37,6 +37,8 @@ class OakStream:
                 self.type = self.StreamType.H264
         elif isinstance(xout, XoutDepth):
             self.type = self.StreamType.DEPTH
+        elif isinstance(xout, XoutDisparity):
+            self.type = self.StreamType.RAW
         elif isinstance(xout, XoutFrames):
             self.type = self.StreamType.RAW
         else:

--- a/depthai_sdk/src/depthai_sdk/recorders/video_recorder.py
+++ b/depthai_sdk/src/depthai_sdk/recorders/video_recorder.py
@@ -16,7 +16,6 @@ class VideoRecorder(Recorder):
     _writers: Dict[str, Any]
 
     def __init__(self, folder: Path, xouts: List[XoutFrames]):
-
         self.folder = folder
 
         self._stream_type = dict()
@@ -26,17 +25,19 @@ class VideoRecorder(Recorder):
 
             name = xout.frames.friendly_name or xout.frames.name
             stream = OakStream(xout)
+            fourcc = stream.fourcc()  # TODO add default fourcc? stream.fourcc() can be None.
             if stream.isRaw():
                 from .video_writers.video_writer import VideoWriter
-                self._writer[name] = VideoWriter(folder, name, stream.fourcc(), xout.fps)
+                self._writer[name] = VideoWriter(folder, name, fourcc, xout.fps)
             else:
                 try:
                     from .video_writers.av_writer import AvWriter
-                    self._writer[name] = AvWriter(folder, name, stream.fourcc(), xout.fps)
+                    self._writer[name] = AvWriter(folder, name, fourcc, xout.fps)
                 except:
+                    # TODO here can be other errors, not only import error
                     print("'av' library is not installed, depthai-record will save uncontainerized encoded streams.")
                     from .video_writers.file_writer import FileWriter
-                    self._writer[name] = FileWriter(folder, name, stream.fourcc())
+                    self._writer[name] = FileWriter(folder, name, fourcc)
 
     def write(self, name: str, frame: dai.ImgFrame):
         self._writer[name].write(frame)

--- a/depthai_sdk/src/depthai_sdk/recorders/video_writers/av_writer.py
+++ b/depthai_sdk/src/depthai_sdk/recorders/video_writers/av_writer.py
@@ -1,8 +1,10 @@
-from pathlib import Path
-import av
 from datetime import timedelta
-import depthai as dai
 from fractions import Fraction
+from pathlib import Path
+
+import av
+import depthai as dai
+
 
 class AvWriter:
     start_ts: timedelta = None
@@ -11,6 +13,7 @@ class AvWriter:
     def __init__(self, folder: Path, name: str, fourcc: str, fps: float):
         self.start_ts = None
         self.file = av.open(str(folder / f"{name}.mp4"), 'w')
+
         stream = self.file.add_stream(fourcc, rate=int(fps))
         stream.time_base = Fraction(1, 1000 * 1000)  # Microseconds
 
@@ -20,7 +23,6 @@ class AvWriter:
 
     def close(self):
         self.file.close()
-
 
     def write(self, frame: dai.ImgFrame):
         packet = av.Packet(frame.getData())  # Create new packet with byte array

--- a/depthai_sdk/src/depthai_sdk/recorders/video_writers/file_writer.py
+++ b/depthai_sdk/src/depthai_sdk/recorders/video_writers/file_writer.py
@@ -1,15 +1,15 @@
 from pathlib import Path
 import depthai as dai
 
+
 class FileWriter:
     file = None
 
     def __init__(self, folder: Path, name: str, fourcc: str):
-        self.file = open(str(folder / f"{name}.{fourcc}"), 'wb')
+        self.file = open(str(folder / f"{name}.{fourcc or '.dat'}"), 'wb')
 
     def close(self):
         self.file.close()
-
 
     def write(self, frame: dai.ImgFrame):
         self.file.write(frame.getData())

--- a/depthai_sdk/src/depthai_sdk/recorders/video_writers/video_writer.py
+++ b/depthai_sdk/src/depthai_sdk/recorders/video_writers/video_writer.py
@@ -2,6 +2,7 @@ from pathlib import Path
 import depthai as dai
 import cv2
 
+
 class VideoWriter:
     file = None
     _fps: float
@@ -15,9 +16,9 @@ class VideoWriter:
         w = frame.getWidth()
         h = frame.getHeight()
 
-        if frame.getType() == dai.ImgFrame.Type.RAW16: # Depth
+        if frame.getType() == dai.ImgFrame.Type.RAW16:  # Depth
             fourcc = "Y16 "
-        elif frame.getType() == dai.ImgFrame.Type.RAW8: # Mono Cams
+        elif frame.getType() == dai.ImgFrame.Type.RAW8:  # Mono Cams
             fourcc = "GREY"
         else:
             fourcc = "I420"
@@ -26,12 +27,10 @@ class VideoWriter:
                                     cv2.VideoWriter_fourcc(*fourcc),
                                     self._fps,
                                     (w, h),
-                                    isColor=fourcc=="I420")
-
+                                    isColor=fourcc == "I420")
 
     def close(self):
         self.file.release()
-
 
     def write(self, frame: dai.ImgFrame):
         if self.file is None:


### PR DESCRIPTION
- Fixed the errors that didn't allow user to record depth/disparity using `oak.visualize(..., record='...'))`
- Also fixed the problem with recording disparity data, and saving depth data (they were saved as `file_name.None`, now it's `file_name.dat`