### PR TITLE
Add python versions workflows

### DIFF
--- a/.github/workflows/test_install_requirements.yml
+++ b/.github/workflows/test_install_requirements.yml
@@ -16,22 +16,22 @@
      runs-on: ubuntu-latest
      strategy:
        matrix:
-          python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+          python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
           container_image: ["fedora:34", "fedora:35", "fedora:36", "ubuntu:20.04", "ubuntu:22.04"]
        fail-fast: false
      container:
        image: ${{ matrix.container_image }}
      steps:
        - uses: actions/checkout@v3
-       - uses: actions/setup-python@v4
-         with:
-           python-version: ${{ matrix.python-version }}
        - name: Install sudo
          if: startsWith(matrix.container_image, 'fedora') == true
          run: yum update -y && yum install -y sudo curl
        - name: Install sudo
          if: startsWith(matrix.container_image, 'ubuntu') == true
          run: apt-get update  -qq && apt-get -qq install sudo curl
+       - uses: actions/setup-python@v4
+         with:
+           python-version: ${{ matrix.python-version }}
        - name: Install dependencies
          run: |
            ln -snf /usr/share/zoneinfo/UTC /etc/localtime && echo UTC > /etc/timezone
@@ -44,7 +44,7 @@
    test_macos:
       strategy:
         matrix:
-          python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+          python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
           os: ["macos-11", "macos-12"]
         fail-fast: false
       runs-on: ${{ matrix.os }}
@@ -65,7 +65,7 @@
       runs-on: windows-latest
       strategy:
         matrix:
-          python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+          python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         fail-fast: false
       steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test_install_requirements.yml
+++ b/.github/workflows/test_install_requirements.yml
@@ -25,10 +25,10 @@
        - uses: actions/checkout@v3
        - name: Install sudo
          if: startsWith(matrix.container_image, 'fedora') == true
-         run: yum update -y && yum install -y sudo curl
+         run: yum update -y && yum install -y sudo curl libssl-dev
        - name: Install sudo
          if: startsWith(matrix.container_image, 'ubuntu') == true
-         run: apt-get update  -qq && apt-get -qq install sudo curl
+         run: apt-get update  -qq && apt-get -qq install sudo curl libssl-dev
        - uses: actions/setup-python@v4
          with:
            python-version: ${{ matrix.python-version }}

--- a/.github/workflows/test_install_requirements.yml
+++ b/.github/workflows/test_install_requirements.yml
@@ -16,11 +16,15 @@
      runs-on: ubuntu-latest
      strategy:
        matrix:
+          python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
           container_image: ["fedora:34", "fedora:35", "fedora:36", "ubuntu:20.04", "ubuntu:22.04"]
      container:
        image: ${{ matrix.container_image }}
      steps:
        - uses: actions/checkout@v3
+       - uses: actions/setup-python@v4
+         with:
+           python-version: ${{ matrix.python-version }}
        - name: Install sudo
          if: startsWith(matrix.container_image, 'fedora') == true
          run: yum update -y && yum install -y sudo curl
@@ -39,10 +43,14 @@
    test_macos:
       strategy:
         matrix:
+          python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
           os: ["macos-11", "macos-12"]
       runs-on: ${{ matrix.os }}
       steps:
        - uses: actions/checkout@v3
+       - uses: actions/setup-python@v4
+         with:
+           python-version: ${{ matrix.python-version }}
        - name: Install dependencies
          run: |
            curl -fL https://docs.luxonis.com/install_dependencies.sh > install_dependencies.sh
@@ -53,8 +61,14 @@
            python3 install_requirements.py
    test_windows:
       runs-on: windows-latest
+      strategy:
+        matrix:
+          python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
       steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+           python-version: ${{ matrix.python-version }}
       - name: Download chocolatey
         shell: pwsh
         run: Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))

--- a/.github/workflows/test_install_requirements.yml
+++ b/.github/workflows/test_install_requirements.yml
@@ -18,6 +18,7 @@
        matrix:
           python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
           container_image: ["fedora:34", "fedora:35", "fedora:36", "ubuntu:20.04", "ubuntu:22.04"]
+       fail-fast: false
      container:
        image: ${{ matrix.container_image }}
      steps:
@@ -45,6 +46,7 @@
         matrix:
           python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
           os: ["macos-11", "macos-12"]
+        fail-fast: false
       runs-on: ${{ matrix.os }}
       steps:
        - uses: actions/checkout@v3
@@ -64,6 +66,7 @@
       strategy:
         matrix:
           python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        fail-fast: false
       steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/test_install_requirements.yml
+++ b/.github/workflows/test_install_requirements.yml
@@ -43,8 +43,8 @@
      runs-on: ${{ matrix.os }}
      steps:
        - uses: actions/checkout@v3
-       - name: Install sudo
-         run: apt-get update  -qq && apt-get -qq install sudo curl
+       - name: Install curl
+         run: sudo apt-get update  -qq && sudo apt-get -qq install curl
        - uses: actions/setup-python@v4
          with:
            python-version: ${{ matrix.python-version }}

--- a/.github/workflows/test_install_requirements.yml
+++ b/.github/workflows/test_install_requirements.yml
@@ -12,12 +12,11 @@
 
  # A workflow run is made up of one or more jobs that can run sequentially or in parallel
  jobs:
-   test_linux:
+   test_linux_fedora:
      runs-on: ubuntu-latest
      strategy:
        matrix:
-          python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
-          container_image: ["fedora:34", "fedora:35", "fedora:36", "ubuntu:20.04", "ubuntu:22.04"]
+          container_image: ["fedora:34", "fedora:35", "fedora:36"]
        fail-fast: false
      container:
        image: ${{ matrix.container_image }}
@@ -25,10 +24,27 @@
        - uses: actions/checkout@v3
        - name: Install sudo
          if: startsWith(matrix.container_image, 'fedora') == true
-         run: yum update -y && yum install -y sudo curl libssl-dev
+         run: yum update -y && yum install -y sudo curl
+       - name: Install dependencies
+         run: |
+           ln -snf /usr/share/zoneinfo/UTC /etc/localtime && echo UTC > /etc/timezone
+           curl -fL https://docs.luxonis.com/install_dependencies.sh > install_dependencies.sh
+           sed '/udevadm control --reload-rules && sudo udevadm trigger/d' install_dependencies.sh > tmp_script.sh
+           bash tmp_script.sh
+       - name: Install example requirements
+         run: |
+           python3 install_requirements.py
+   test_linux_ubuntu:
+     strategy:
+       matrix:
+          python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+          os: ["ubuntu-20.04", "ubuntu-22.04"]
+       fail-fast: false
+     runs-on: ${{ matrix.os }}
+     steps:
+       - uses: actions/checkout@v3
        - name: Install sudo
-         if: startsWith(matrix.container_image, 'ubuntu') == true
-         run: apt-get update  -qq && apt-get -qq install sudo curl libssl-dev
+         run: apt-get update  -qq && apt-get -qq install sudo curl
        - uses: actions/setup-python@v4
          with:
            python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
Test different python versions as well. 
I didn't include versions for fedora, since `setup-python` action doesn't work out of the box
in containers in some cases, but we have the Fedora listed as supported by the community only officially,
so testing only "stock" pythons for Fedora should be fine.