### PR TITLE
Fix exceptions that occured because of reading the EEPROM data at inappropriate time

### DIFF
--- a/test_ui.py
+++ b/test_ui.py
@@ -328,9 +328,9 @@ class DepthAICamera():
         self.device_name = self.device.getDeviceName()
 
         self.eepromUnionData = {}
-        calibHandler = self.device.readCalibration2()
+        calibHandler = self.device.readCalibrationOrDefault()
         self.eepromUnionData['calibrationUser'] = calibHandler.eepromToJson()
-        calibHandler = self.device.readFactoryCalibration()
+        calibHandler = self.device.readFactoryCalibrationOrDefault()
         self.eepromUnionData['calibrationFactory'] = calibHandler.eepromToJson()
         self.eepromUnionData['calibrationUserRaw'] = self.device.readCalibrationRaw()
         self.eepromUnionData['calibrationFactoryRaw'] = self.device.readFactoryCalibrationRaw()

--- a/test_ui.py
+++ b/test_ui.py
@@ -328,6 +328,8 @@ class DepthAICamera():
         self.device_name = self.device.getDeviceName()
 
         self.eepromUnionData = {}
+    
+    def update_eeprom_uinion_data_log(self):
         calibHandler = self.device.readCalibrationOrDefault()
         self.eepromUnionData['calibrationUser'] = calibHandler.eepromToJson()
         calibHandler = self.device.readFactoryCalibrationOrDefault()
@@ -1280,6 +1282,8 @@ class UiTests(QtWidgets.QMainWindow):
             test_result['eeprom_data'] = ''
 
 
+        # save data for logging 
+        self.depth_camera.update_eeprom_uinion_data_log()
         try:
             self.flash_data_512 = self.depth_camera.device.flashRead(512)
         except:

--- a/test_ui.py
+++ b/test_ui.py
@@ -443,32 +443,6 @@ class DepthAICamera():
             return False, None
         return True, image
 
-    def flash_eeprom(self):
-        global eepromDataJson
-        try:
-            device_calib = self.device.readCalibration()
-            device_calib.eepromToJsonFile(CALIB_BACKUP_FILE)
-            print('Calibraton Data on the device is backed up at: ', CALIB_BACKUP_FILE, sep='\n')
-
-            # Opening JSON file
-            if eepromDataJson is None:
-                return False
-
-            eepromDataJson['batchTime'] = int(time.time())
-
-            calib_data = dai.CalibrationHandler.fromJson(eepromDataJson)
-
-            # Flash both factory & user areas
-            self.device.flashFactoryCalibration(calib_data)
-            self.device.flashCalibration2(calib_data)
-        except Exception as ex:
-            errorMsg = f'Calibration Flash Failed: {ex}'
-            print(errorMsg)
-            return (False, errorMsg, eepromDataJson)
-
-        print('Calibration Flash Successful')
-        return (True, '', eepromDataJson)
-
 
 eepromDataJson = None
 calib_path = None
@@ -1291,7 +1265,7 @@ class UiTests(QtWidgets.QMainWindow):
         self.print_logs('EEPROM backup saved at')
         self.print_logs(CALIB_BACKUP_FILE)
         if not eeprom_written:
-            eeprom_success, eeprom_msg, eeprom_data = self.depth_camera.flash_eeprom()
+            eeprom_success, eeprom_msg, eeprom_data = self.flash_eeprom(self.depth_camera.device)
         if eeprom_success:
             self.print_logs('Flash EEPROM successful!', 'GREEN')
             test_result['eeprom_res'] = 'PASS'
@@ -1437,7 +1411,6 @@ class UiTests(QtWidgets.QMainWindow):
             test_result['nor_flash_res'] = 'FAIL'
             return False
 
-    # Copy-pasted, to not be under device. FIXME
     def flash_eeprom(self, device):
         global eepromDataJson
         try:


### PR DESCRIPTION
The error showd when running the program with unflashed OAK-D-LITE because I was trying to read the EEPROM when none were flashed yet.

To fix the issue I added `orDefault` to `readCalibration` and `readFactoryCalibration` calls. This made the error disapear but logged an empty EEPROM. So I moved the EEPROM reading code further down the code path where in all cases the device is flashed.

Also I removed the duplicated function `flash_eeprom` with prior discussion with @alex-luxonis (see 11acce4d30ecad83958cc8d899c50a2f7b5e34fc), because at first I thought it could be a good place to store the EEPROM data for logging. But later I decided to move the logging even further down the code path. If the removal poses to much risk, we can revet the commit.