### PR TITLE
Updated 180 deg rotation.

### DIFF
--- a/depthai_sdk/src/depthai_sdk/components/camera_component.py
+++ b/depthai_sdk/src/depthai_sdk/components/camera_component.py
@@ -89,7 +89,7 @@ class CameraComponent(Component):
             self.stream_size = res
             self.stream = self.node.out
             if self._rotation:
-                rot_manip = self._create_rotation_manip(pipeline) if self._rotation else None
+                rot_manip = self._create_rotation_manip(pipeline)
                 self.node.out.link(rot_manip.inputImage)
                 self.stream = rot_manip.out
             else:
@@ -126,9 +126,12 @@ class CameraComponent(Component):
             self._config_camera_args(self._args)
 
         if self._rotation:
-            rot_manip = self._create_rotation_manip(pipeline) if self._rotation else None
-            self.stream.link(rot_manip.inputImage)
-            self.stream = rot_manip.out
+            if self._rotation == 180 and not self.is_replay():
+                self.node.setImageOrientation(dai.CameraImageOrientation.ROTATE_180_DEG)
+            else:
+                rot_manip = self._create_rotation_manip(pipeline)
+                self.stream.link(rot_manip.inputImage)
+                self.stream = rot_manip.out
 
         if self.encoder:
             self.encoder.setDefaultProfilePreset(self._get_fps(), self._encoderProfile)


### PR DESCRIPTION
DDR usage for pipeline below for prev. version of 180 deg rotation: 98_141_184/357_154_815 

DDR usage for pipeline below for updated version of 180 deg rotation: 73_254_912/357_154_815

```python
from depthai_sdk import OakCamera, CameraComponent

with OakCamera(rotation=180) as oak:
    cam_component: CameraComponent = oak.create_camera(source="color", fps=10, resolution="1080p")
    oak.visualize(cam_component)
    oak.start(blocking=True)
```