### PR TITLE
Added an option to name the streams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ resources/*.json
 # Virtual environment
 virtualenv/
 venv/
+.venv/
 
 # DepthAI recordings
 recordings/

--- a/depthai_sdk/examples/mixed/sync_multiple_outputs.py
+++ b/depthai_sdk/examples/mixed/sync_multiple_outputs.py
@@ -3,9 +3,9 @@ from typing import Dict
 from depthai_sdk import OakCamera
 
 with OakCamera() as oak:
-    color = oak.create_camera('color', encode='h264')
-    nn = oak.create_nn('mobilenet-ssd', color)
-    nn2 = oak.create_nn('face-detection-retail-0004', color)
+    color = oak.create_camera('color', encode='h264', name='color')
+    nn = oak.create_nn('mobilenet-ssd', color, name='mobilenet')
+    nn2 = oak.create_nn('face-detection-retail-0004', color, name='face-detection')
     # oak.visualize([nn.out.main, nn.out.passthrough])
     # oak.visualize(nn.out.spatials, scale=1 / 2)
     def cb(msgs: Dict):

--- a/depthai_sdk/setup.py
+++ b/depthai_sdk/setup.py
@@ -1,7 +1,6 @@
 import io
 
 from setuptools import setup
-import pkg_resources
 
 with open('requirements.txt') as f:
     requirements = f.readlines()

--- a/depthai_sdk/setup.py
+++ b/depthai_sdk/setup.py
@@ -1,9 +1,13 @@
 import io
 
 from setuptools import setup
+import pkg_resources
 
 with open('requirements.txt') as f:
-    required = f.readlines()
+    requirements = f.readlines()
+
+install_requires=[requirement for requirement in requirements if '--' not in requirement]
+
 
 setup(
     name='depthai-sdk',
@@ -18,7 +22,7 @@ setup(
     license='MIT',
     packages=['depthai_sdk'],
     package_dir={"": "src"},  # https://stackoverflow.com/a/67238346/5494277
-    install_requires=required,
+    install_requires=install_requires,
     include_package_data=True,
     extras_require={
         "visualize": ['PySide2',

--- a/depthai_sdk/src/depthai_sdk/classes/output_config.py
+++ b/depthai_sdk/src/depthai_sdk/classes/output_config.py
@@ -32,8 +32,7 @@ class OutputConfig(BaseConfig):
                  callback: Callable,
                  visualizer: Visualizer = None,
                  visualizer_enabled: bool = False,
-                 record_path: Optional[str] = None,
-                 stream_name: Optional[str] = None):
+                 record_path: Optional[str] = None):
         self.output = output
         self.callback = callback
         self.visualizer = visualizer

--- a/depthai_sdk/src/depthai_sdk/classes/output_config.py
+++ b/depthai_sdk/src/depthai_sdk/classes/output_config.py
@@ -32,7 +32,8 @@ class OutputConfig(BaseConfig):
                  callback: Callable,
                  visualizer: Visualizer = None,
                  visualizer_enabled: bool = False,
-                 record_path: Optional[str] = None):
+                 record_path: Optional[str] = None,
+                 stream_name: Optional[str] = None):
         self.output = output
         self.callback = callback
         self.visualizer = visualizer

--- a/depthai_sdk/src/depthai_sdk/components/camera_component.py
+++ b/depthai_sdk/src/depthai_sdk/components/camera_component.py
@@ -35,6 +35,7 @@ class CameraComponent(Component):
                  encode: Union[None, str, bool, dai.VideoEncoderProperties.Profile] = None,
                  rotation: Optional[int] = None,
                  replay: Optional[Replay] = None,
+                 name: Optional[str] = None,
                  args: Dict = None,
                  ):
         """
@@ -58,6 +59,7 @@ class CameraComponent(Component):
         self._source = source
         self._replay: Replay = replay
         self._args = args
+        self.name = name
 
         if rotation not in [None, 0, 90, 180, 270]:
             raise ValueError(f'Angle {rotation} not supported! Use 0, 90, 180, 270.')
@@ -366,10 +368,10 @@ class CameraComponent(Component):
         if self.is_replay():
             return ReplayStream(self._source)
         elif self.is_mono():
-            return StreamXout(self.node.id, self.stream)
+            return StreamXout(self.node.id, self.stream, name=self.name)
         else:  # ColorCamera
             self.node.setVideoNumFramesPool(10)
-            return StreamXout(self.node.id, self.stream)
+            return StreamXout(self.node.id, self.stream, name=self.name)
 
     """
     Available outputs (to the host) of this component

--- a/depthai_sdk/src/depthai_sdk/components/stereo_component.py
+++ b/depthai_sdk/src/depthai_sdk/components/stereo_component.py
@@ -45,6 +45,7 @@ class StereoComponent(Component):
                  right: Union[None, CameraComponent, dai.node.MonoCamera] = None,  # Right mono camera
                  replay: Optional[Replay] = None,
                  args: Any = None,
+                 name: Optional[str] = None
                  ):
         """
         Args:
@@ -55,6 +56,7 @@ class StereoComponent(Component):
             right (None / dai.None.Output / CameraComponent): Right mono camera source. Will get handled by Camera object.
             replay (Replay object, optional): Replay
             args (Any, optional): Use user defined arguments when constructing the pipeline
+            name (str, optional): Name of the output stream
         """
         super().__init__()
         self.out = self.Out(self)
@@ -63,6 +65,7 @@ class StereoComponent(Component):
         self._resolution = resolution
         self._fps = fps
         self._args = args
+        self.name = name
 
         self.left = left
         self.right = right
@@ -208,8 +211,8 @@ class StereoComponent(Component):
             fps = self._comp.left.getFps() if self._comp._replay is None else self._comp._replay.getFps()
 
             out = XoutDisparity(
-                disparity_frames=StreamXout(self._comp.node.id, self._comp.disparity),
-                mono_frames=StreamXout(self._comp.node.id, self._comp._right_stream),
+                disparity_frames=StreamXout(self._comp.node.id, self._comp.disparity, name=self._comp.name),
+                mono_frames=StreamXout(self._comp.node.id, self._comp._right_stream, name=self._comp.name),
                 max_disp=self._comp.node.getMaxDisparity(),
                 fps=fps,
                 colorize=self._comp._colorize,
@@ -225,8 +228,8 @@ class StereoComponent(Component):
             fps = self._comp.left.getFps() if self._comp._replay is None else self._comp._replay.getFps()
             out = XoutDepth(
                 device=device,
-                frames=StreamXout(self._comp.node.id, self._comp.depth),
-                mono_frames=StreamXout(self._comp.node.id, self._comp._right_stream),
+                frames=StreamXout(self._comp.node.id, self._comp.depth, name=self._comp.name),
+                mono_frames=StreamXout(self._comp.node.id, self._comp._right_stream, name=self._comp.name),
                 fps=fps,
                 colorize=self._comp._colorize,
                 colormap=self._comp._colormap,

--- a/depthai_sdk/src/depthai_sdk/oak_camera.py
+++ b/depthai_sdk/src/depthai_sdk/oak_camera.py
@@ -104,6 +104,7 @@ class OakCamera:
                           None, str, dai.ColorCameraProperties.SensorResolution, dai.MonoCameraProperties.SensorResolution] = None,
                       fps: Optional[float] = None,
                       encode: Union[None, str, bool, dai.VideoEncoderProperties.Profile] = None,
+                      name: Optional[str] = None,
                       ) -> CameraComponent:
         """
         Creates Camera component. This abstracts ColorCamera/MonoCamera nodes and supports mocking the camera when
@@ -123,6 +124,7 @@ class OakCamera:
                                encode=encode,
                                rotation=self._rotation,
                                replay=self.replay,
+                               name=name,
                                args=self._args, )
         self._components.append(comp)
         return comp

--- a/depthai_sdk/src/depthai_sdk/oak_camera.py
+++ b/depthai_sdk/src/depthai_sdk/oak_camera.py
@@ -116,6 +116,7 @@ class OakCamera:
             resolution (str/SensorResolution): Sensor resolution of the camera.
             fps (float): Sensor FPS
             encode (bool/str/Profile): Whether we want to enable video encoding (accessible via cameraComponent.out_encoded). If True, it will use MJPEG
+            name (str): Name used to identify the X-out stream. This name will also be associated with the frame in the callback function.
         """
         comp = CameraComponent(self._pipeline,
                                source=source,

--- a/depthai_sdk/src/depthai_sdk/oak_camera.py
+++ b/depthai_sdk/src/depthai_sdk/oak_camera.py
@@ -137,6 +137,7 @@ class OakCamera:
                   tracker: bool = False,  # Enable object tracker - only for Object detection models
                   spatial: Union[None, bool, StereoComponent] = None,
                   decode_fn: Optional[Callable] = None,
+                  name: Optional[str] = None
                   ) -> NNComponent:
         """
         Creates Neural Network component.
@@ -148,6 +149,7 @@ class OakCamera:
             tracker: Enable object tracker, if model is object detector (yolo/mobilenet)
             spatial: Calculate 3D spatial coordinates, if model is object detector (yolo/mobilenet) and depth stream is available
             decode_fn: Custom decoding function for the model's output
+            name (str): Name used to identify the X-out stream. This name will also be associated with the frame in the callback function.
         """
         comp = NNComponent(self._pipeline,
                            model=model,
@@ -157,7 +159,8 @@ class OakCamera:
                            spatial=spatial,
                            decode_fn=decode_fn,
                            replay=self.replay,
-                           args=self._args)
+                           args=self._args,
+                           name=name)
         self._components.append(comp)
         return comp
 
@@ -166,6 +169,7 @@ class OakCamera:
                       fps: Optional[float] = None,
                       left: Union[None, dai.Node.Output, CameraComponent] = None,  # Left mono camera
                       right: Union[None, dai.Node.Output, CameraComponent] = None,  # Right mono camera
+                      name: Optional[str] = None
                       ) -> StereoComponent:
         """
         Create Stereo camera component. If left/right cameras/component aren't specified they will get created internally.
@@ -175,6 +179,7 @@ class OakCamera:
             fps (float): If monochrome cameras aren't already passed, create them and set specified FPS
             left (CameraComponent/dai.node.MonoCamera): Pass the camera object (component/node) that will be used for stereo camera.
             right (CameraComponent/dai.node.MonoCamera): Pass the camera object (component/node) that will be used for stereo camera.
+            name (str): Name used to identify the X-out stream. This name will also be associated with the frame in the callback function.
         """
         comp = StereoComponent(self._pipeline,
                                resolution=resolution,
@@ -182,7 +187,8 @@ class OakCamera:
                                left=left,
                                right=right,
                                replay=self.replay,
-                               args=self._args)
+                               args=self._args,
+                               name=name)
         self._components.append(comp)
         return comp
 

--- a/depthai_sdk/src/depthai_sdk/oak_camera.py
+++ b/depthai_sdk/src/depthai_sdk/oak_camera.py
@@ -306,11 +306,11 @@ class OakCamera:
         """
         return not self._stop
 
-    def poll(self) -> int:
+    def poll(self) -> Optional[int]:
         """
         Poll events; cv2.waitKey, send controls to OAK (if controls are enabled), update, check syncs.
 
-        Returns: key pressed from cv2.waitKey
+        Returns: key pressed from cv2.waitKey, or None if
         """
         key = cv2.waitKey(1)
         if key == ord('q'):
@@ -331,6 +331,7 @@ class OakCamera:
 
         if self.device.isClosed():
             self._stop = True
+            return None
 
         return key
 

--- a/depthai_sdk/src/depthai_sdk/oak_camera.py
+++ b/depthai_sdk/src/depthai_sdk/oak_camera.py
@@ -300,14 +300,16 @@ class OakCamera:
         """
         return not self._stop
 
-    def poll(self):
+    def poll(self) -> int:
         """
         Poll events; cv2.waitKey, send controls to OAK (if controls are enabled), update, check syncs.
+
+        Returns: key pressed from cv2.waitKey
         """
         key = cv2.waitKey(1)
         if key == ord('q'):
             self._stop = True
-            return
+            return key
 
         # TODO: check if components have controls enabled and check whether key == `control`
 
@@ -316,13 +318,15 @@ class OakCamera:
         if self.replay:
             if self.replay._stop:
                 self._stop = True
-                return
+                return key
 
         for poll in self._polling:
             poll() # Poll all callbacks
 
         if self.device.isClosed():
             self._stop = True
+
+        return key
 
     def build(self) -> dai.Pipeline:
         """

--- a/depthai_sdk/src/depthai_sdk/oak_outputs/xout_base.py
+++ b/depthai_sdk/src/depthai_sdk/oak_outputs/xout_base.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from queue import Empty, Queue
-from typing import List, Callable
+from typing import List, Callable, Optional
 
 import depthai as dai
 
@@ -11,9 +11,12 @@ from depthai_sdk.visualize import Visualizer
 class StreamXout:
     stream: dai.Node.Output
     name: str  # XLinkOut stream name
-    def __init__(self, id: int, out: dai.Node.Output):
+    def __init__(self, id: int, out: dai.Node.Output, name: Optional[str] = None):
         self.stream = out
-        self.name = f"{str(id)}_{out.name}"
+        if name is not None:
+            self.name = name
+        else:
+            self.name = f"{str(id)}_{out.name}"
 
 class ReplayStream(StreamXout):
     def __init__(self, name: str):


### PR DESCRIPTION
> Please note that I am not very familiar with the codebase so if there is something I have missed I am open to changing the implementation or even closing the request.


### Naming the x out streams
Right now it seems to be very hard to know from which camera (left, right, rgb, ...) a packet came from.

Take a look at this example:
```python
from depthai_sdk import OakCamera

with OakCamera() as oak:
	color = oak.create_camera('color')
	left = oak.create_camera('left')
	right = oak.create_camera('right')
	oak.sync([color.out.main, left.out.main, right.out.main], callback=lambda p: print(p))
	oak.start(blocking=True)

# prints
# {'0_preview': <depthai_sdk.classes.packets.FramePacket object at 0x00000164DDCA3400>, '1_out': <depthai_sdk.classes.packets.FramePacket object at 0x00000164DDCA3310>, '2_out': <depthai_sdk.classes.packets.FramePacket object at 0x00000164DDCA3340>}
```

As you can see the frames are labeled with "0_preview", "1_out", "2_out" which is not very developer friendly. Ideally, I would like to have the streams named the same as the camera source ("color", "left", "right" in this example) but I am afraid this would break existing code so I'm proposing a middle ground solution (with minimal change to the SDK source) which allows the user to manually set the stream name when creating a camera.

Here is an example:
```python
from depthai_sdk import OakCamera

with OakCamera() as oak:
	color = oak.create_camera('color', name="color")
	left = oak.create_camera('left', name="left")
	right = oak.create_camera('right', name="right")
	oak.sync([color.out.main, left.out.main, right.out.main], callback=lambda p: print(p))
	oak.start(blocking=True)

# prints
# {'right': <depthai_sdk.classes.packets.FramePacket object at 0x0000012E3FCB80D0>, 'left': <depthai_sdk.classes.packets.FramePacket object at 0x0000012E3FCB89D0>, 'color': <depthai_sdk.classes.packets.FramePacket object at 0x0000012E3FCB8550>}
```

The frames are labeled as specified in the `create_camera` function.

### Fixed `setup.py`

I have also made a small change to the `setup.py`. The `requirements.txt` contains some flags (`--extra-index-url ...`) but the `setup` function expects just a list of requirements. So I added a filter to remove the flags. Please note that you have to provide these flags manually when installing the package like so:
```
pip install --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/ -e ./depthai_sdk
```