### PR TITLE
depthai-sdk Bug fix

### DIFF
--- a/depthai_sdk/src/depthai_sdk/oak_device.py
+++ b/depthai_sdk/src/depthai_sdk/oak_device.py
@@ -6,9 +6,11 @@ from depthai_sdk.oak_outputs.xout_base import XoutBase
 
 
 class OakDevice:
-    device: dai.Device = None
-    # fpsHandlers: Dict[str, FPS] = dict()
-    oak_out_streams: List[XoutBase] = []
+    
+    def __init__(self):
+        self.device: dai.Device = None
+        # fpsHandlers: Dict[str, FPS] = dict()
+        self.oak_out_streams: List[XoutBase] = []
 
     @property
     def image_sensors(self) -> List[dai.CameraBoardSocket]:


### PR DESCRIPTION
Static class variables for OakDevice caused multiple instances to share the same streams