### PR TITLE
Updated depthai for UVC app

### DIFF
--- a/apps/uvc/main.py
+++ b/apps/uvc/main.py
@@ -39,7 +39,7 @@ signal.signal(signal.SIGTERM, lambda *_args: quitEvent.set())
 
 # Pipeline defined, now the device is connected to
 with dai.Device(pipeline, usb2Mode=False) as device:
-    if device.getDeviceInfo().desc.protocol == dai.XLinkProtocol.X_LINK_USB_VSC and device.getUsbSpeed() not in (dai.UsbSpeed.SUPER, dai.UsbSpeed.SUPER_PLUS):
+    if device.getDeviceInfo().protocol == dai.XLinkProtocol.X_LINK_USB_VSC and device.getUsbSpeed() not in (dai.UsbSpeed.SUPER, dai.UsbSpeed.SUPER_PLUS):
         print("This app is temporarily disabled with USB2 connection speed due to known issue. We're working on resolving it. In the meantime, please try again with a USB3 cable/port for the device connection", file=sys.stderr)
         raise SystemExit(1)
     print("\nDevice started, please keep this process running")

--- a/apps/uvc/requirements.txt
+++ b/apps/uvc/requirements.txt
@@ -1,3 +1,3 @@
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/
-depthai==2.17.0.0.dev+e6a4209ba1880a3c0f162a9ce2be5f34ba7579f6
+depthai==2.19.1.0.dev+e88af9a9db3dc630a3011dd52d1f5700cf6bf9b8
 depthai-sdk==1.2.1


### PR DESCRIPTION
Now it works for macOS as well (prebuilt depthai wheels). Note that now the uvc app throws errors every so often, even though still capture is never triggered, but this can be ignored:
```[18443010D116631200] [1.3] [47.464] [ColorCamera(0)] [error] Still capture ignored, as the output is not connected
[18443010D116631200] [1.3] [47.497] [ColorCamera(0)] [error] Still capture ignored, as the output is not connected
[18443010D116631200] [1.3] [47.531] [ColorCamera(0)] [error] Still capture ignored, as the output is not connected```