### PR TITLE
[Hotfix] depthai demo openvino problem

### DIFF
--- a/.github/workflows/test_install_requirements.yml
+++ b/.github/workflows/test_install_requirements.yml
@@ -93,7 +93,7 @@
         run: Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
       - name: Install dependencies
         shell: pwsh
-        run: choco install cmake git python pycharm-community -y
+        run: choco install cmake git python --version 3.10 pycharm-community -y
       - name: Install requrirements
         run: |
           python install_requirements.py

--- a/depthai_sdk/requirements.txt
+++ b/depthai_sdk/requirements.txt
@@ -5,7 +5,7 @@ blobconverter>=1.2.8
 pytube>=12.1.0
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/
 # This specific commit is needed for the debug mode (oak.show_graph()). TODO: update when depthai has new release
-depthai>=2.20.0.0
+depthai>=2.20.1.0
 PyTurboJPEG==1.6.4
 marshmallow==3.17.0
 distinctipy

--- a/depthai_sdk/setup.py
+++ b/depthai_sdk/setup.py
@@ -10,7 +10,7 @@ install_requires=[requirement for requirement in requirements if '--' not in req
 
 setup(
     name='depthai-sdk',
-    version='1.9.2',
+    version='1.9.3',
     description='This package provides an abstraction of the DepthAI API library.',
     long_description=io.open("README.md", encoding="utf-8").read(),
     long_description_content_type="text/markdown",

--- a/depthai_sdk/src/depthai_sdk/managers/blob_manager.py
+++ b/depthai_sdk/src/depthai_sdk/managers/blob_manager.py
@@ -86,7 +86,7 @@ class BlobManager:
         if self._useBlob:
             return self._blobPath
         version = openvinoVersion.name.replace("VERSION_", "").replace("_", ".")
-        if version == "2022.1":
+        if version == "2022.1" or version == "???":
             version = "2021.4" #FIXME
         if self._useZoo:
             try:

--- a/depthai_sdk/src/depthai_sdk/managers/blob_manager.py
+++ b/depthai_sdk/src/depthai_sdk/managers/blob_manager.py
@@ -86,7 +86,7 @@ class BlobManager:
         if self._useBlob:
             return self._blobPath
         version = openvinoVersion.name.replace("VERSION_", "").replace("_", ".")
-        if version == "2022.1" or version == "???":
+        if version == "2022.1" or version == "UNIVERSAL":
             version = "2021.4" #FIXME
         if self._useZoo:
             try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ depthai-sdk
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-depthai-data-local/wheels/
 pyqt5>5,<5.15.6 ; platform_machine != "armv6l" and platform_machine != "armv7l" and platform_machine != "aarch64" and platform_machine != "arm64"
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/
-depthai>=2.20.0.0
+depthai>=2.20.1.0
 Qt.py


### PR DESCRIPTION
User on discord reported [this problem](https://discord.com/channels/790680891252932659/924798783521439804/1067196573253107883); with new depthai 2.20 getting default openvino version fails, so blobconverter can't download models.
Current workaround: `python3 depthai_demo.py --openvinoVersion 2021_4`
![image](https://user-images.githubusercontent.com/18037362/214173860-7d04ced2-b3e2-4f56-a5e3-b4809e92a50f.png)
