### PR TITLE
Check if markers were detected on undistorted image

### DIFF
--- a/depthai_helpers/calibration_utils.py
+++ b/depthai_helpers/calibration_utils.py
@@ -944,6 +944,7 @@ class StereoCalibration(object):
         imgpoints_r = []
         imgpoints_l = []
         # new_imagePairs = []
+        no_markers_found_error_count = 0
         for i, image_data_pair in enumerate(image_data_pairs):
             #             gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
             marker_corners_l, ids_l, rejectedImgPoints = cv2.aruco.detectMarkers(
@@ -959,9 +960,13 @@ class StereoCalibration(object):
                                                                             rejectedCorners=rejectedImgPoints)
 
             if ids_l is None or ids_r is None:
+                no_markers_found_error_count += 1
                 print(f'No markers found in the undistorted image pair {images_left[i]} and {images_right[i]}')
                 continue
 
+            if no_markers_found_error_count > 2:
+                raise Exception('No markers found in more than 2 undistored images. Please make sure that your calibration board is flat and not too close to the border of the image.')
+                
             print(f'Marekrs length r is {len(marker_corners_r)}')
             print(f'Marekrs length l is {len(marker_corners_l)}')
             res2_l = cv2.aruco.interpolateCornersCharuco(

--- a/depthai_helpers/calibration_utils.py
+++ b/depthai_helpers/calibration_utils.py
@@ -957,6 +957,11 @@ class StereoCalibration(object):
             marker_corners_r, ids_r, _, _ = cv2.aruco.refineDetectedMarkers(image_data_pair[1], self.board,
                                                                             marker_corners_r, ids_r,
                                                                             rejectedCorners=rejectedImgPoints)
+
+            if ids_l is None or ids_r is None:
+                print(f'No markers found in the undistorted image pair {images_left[i]} and {images_right[i]}')
+                continue
+
             print(f'Marekrs length r is {len(marker_corners_r)}')
             print(f'Marekrs length l is {len(marker_corners_l)}')
             res2_l = cv2.aruco.interpolateCornersCharuco(


### PR DESCRIPTION
In the current state we check if the cornerrs are detected before capturing the image. But some times the undistorted image is slightly cropped and the markers are no longer visible. This causes an error in the `test_epipolar_charuco` function when calling `cv2.aruco.interpolateCornersCharuco` we get this error:
```
Device closed in exception..
OpenCV(4.5.5) D:\a\opencv-python\opencv-python\opencv_contrib\modules\aruco\src\charuco.cpp:448: error: (-215:Assertion failed) _markerCorners.total() == _markerIds.getMat().total() && _markerIds.getMat().total() > 0 in function 'cv::aruco::_interpolateCornersCharucoLocalHom'

Traceback (most recent call last):
  File "C:\Users\user\depthai\calibrate.py", line 911, in calibrate
    status, result_config = stereo_calib.calibrate(
  File "C:\Users\user\depthai\depthai_helpers\calibration_utils.py", line 179, in calibrate
    left_cam_info['extrinsics']['epipolar_error'] = self.test_epipolar_charuco(
  File "C:\Users\user\depthai\depthai_helpers\calibration_utils.py", line 962, in test_epipolar_charuco
    res2_l = cv2.aruco.interpolateCornersCharuco(
cv2.error: OpenCV(4.5.5) D:\a\opencv-python\opencv-python\opencv_contrib\modules\aruco\src\charuco.cpp:448: error: (-215:Assertion failed) _markerCorners.total() == _markerIds.getMat().total() && _markerIds.getMat().total() > 0 in function 'cv::aruco::_interpolateCornersCharucoLocalHom'
```

To fix this I added a check that skips the frames with no detected markers and warn the user.