### PR TITLE
On-device stereo colorization

### DIFF
--- a/depthai_sdk/examples/StereoComponent/stereo.py
+++ b/depthai_sdk/examples/StereoComponent/stereo.py
@@ -5,13 +5,10 @@ from depthai_sdk.components.stereo_component import WLSLevel
 from depthai_sdk.visualize.configs import StereoColor
 
 with OakCamera() as oak:
-    stereo = oak.create_stereo('800p', fps=30)
-    stereo.config_postprocessing(
-        colorize=StereoColor.GRAY,
-        colormap=cv2.COLORMAP_BONE,
-        wls_filter=True,
-        wls_level=WLSLevel.HIGH
-    )
+    stereo = oak.create_stereo('800p', fps=30, encode='h264')
+
+    stereo.config_postprocessing(colorize=StereoColor.RGBD, colormap=cv2.COLORMAP_MAGMA)
+    stereo.config_wls(wls_level=WLSLevel.MEDIUM)
 
     oak.visualize(stereo.out.disparity)
     oak.start(blocking=True)

--- a/depthai_sdk/setup.py
+++ b/depthai_sdk/setup.py
@@ -9,7 +9,7 @@ install_requires = [requirement for requirement in requirements if '--' not in r
 
 setup(
     name='depthai-sdk',
-    version='1.9.3.1',
+    version='1.9.4',
     description='This package provides an abstraction of the DepthAI API library.',
     long_description=io.open("README.md", encoding="utf-8").read(),
     long_description_content_type="text/markdown",

--- a/depthai_sdk/src/depthai_sdk/components/stereo_component.py
+++ b/depthai_sdk/src/depthai_sdk/components/stereo_component.py
@@ -32,8 +32,8 @@ class StereoComponent(Component):
                  replay: Optional[Replay] = None,
                  args: Any = None,
                  name: Optional[str] = None,
-                 encode: Union[None, str, bool, dai.VideoEncoderProperties.Profile] = None
-                 ):
+                 encode: Union[None, str, bool, dai.VideoEncoderProperties.Profile] = None,
+                 colormap: Optional[dai.Colormap] = None):
         """
         Args:
             pipeline (dai.Pipeline): DepthAI pipeline
@@ -44,15 +44,19 @@ class StereoComponent(Component):
             replay (Replay object, optional): Replay
             args (Any, optional): Use user defined arguments when constructing the pipeline
             name (str, optional): Name of the output stream
+            encode (str/bool/Profile, optional): Encode the output stream
+            colormap (dai.Colormap, optional): Colormap to apply to the output stream
         """
         super().__init__()
         self.out = self.Out(self)
 
-        left: Union[None, CameraComponent, dai.node.MonoCamera, dai.node.ColorCamera, dai.Node.Output]
-        right: Union[None, CameraComponent, dai.node.MonoCamera, dai.node.ColorCamera, dai.Node.Output]
+        self.left: Union[None, CameraComponent, dai.node.MonoCamera, dai.node.ColorCamera, dai.Node.Output]
+        self.right: Union[None, CameraComponent, dai.node.MonoCamera, dai.node.ColorCamera, dai.Node.Output]
 
-        _left_stream: dai.Node.Output
-        _right_stream: dai.Node.Output
+        self._left_stream: dai.Node.Output
+        self._right_stream: dai.Node.Output
+
+        self.colormap = colormap
 
         self._replay: Optional[Replay] = replay
         self._resolution: Optional[Union[str, dai.MonoCameraProperties.SensorResolution]] = resolution
@@ -74,7 +78,7 @@ class StereoComponent(Component):
 
         # Configuration variables
         self._colorize = None
-        self._colormap = None
+        self._postprocess_colormap = None
         self._use_wls_filter = None
         self._wls_level = None
         self._wls_lambda = None
@@ -129,6 +133,14 @@ class StereoComponent(Component):
             self._left_stream.link(self.node.left)
             self._right_stream.link(self.node.right)
 
+        colormap_manip = None
+        if self.colormap:
+            colormap_manip = pipeline.create(dai.node.ImageManip)
+            colormap_manip.initialConfig.setColormap(self.colormap, self.node.initialConfig.getMaxDisparity())
+            colormap_manip.initialConfig.setFrameType(dai.ImgFrame.Type.NV12)
+            colormap_manip.setMaxOutputFrameSize(1200 * 800 * 3)
+            self.node.disparity.link(colormap_manip.inputImage)
+
         if self.encoder:
             try:
                 fps = self.left.get_fps()  # CameraComponent
@@ -136,7 +148,10 @@ class StereoComponent(Component):
                 fps = self.left.getFps()  # MonoCamera
 
             self.encoder.setDefaultProfilePreset(fps, self._encoderProfile)
-            self.node.disparity.link(self.encoder.input)
+            if colormap_manip:
+                colormap_manip.out.link(self.encoder.input)
+            else:
+                self.node.disparity.link(self.encoder.input)
 
         self.node.setOutputSize(1200, 800)
 
@@ -207,7 +222,7 @@ class StereoComponent(Component):
         elif isinstance(colorize, str):
             self._colorize = StereoColor[colorize.upper()]
 
-        self._colormap = colormap
+        self._postprocess_colormap = colormap
         self._use_wls_filter = wls_filter
 
         if isinstance(wls_level, WLSLevel):
@@ -262,7 +277,7 @@ class StereoComponent(Component):
                 max_disp=self._comp.node.getMaxDisparity(),
                 fps=fps,
                 colorize=self._comp._colorize,
-                colormap=self._comp._colormap,
+                colormap=self._comp._postprocess_colormap,
                 use_wls_filter=self._comp._use_wls_filter,
                 wls_level=self._comp._wls_level,
                 wls_lambda=self._comp._wls_lambda,
@@ -279,7 +294,7 @@ class StereoComponent(Component):
                 mono_frames=StreamXout(self._comp.node.id, self._comp._right_stream, name=self._comp.name),
                 fps=fps,
                 colorize=self._comp._colorize,
-                colormap=self._comp._colormap,
+                colormap=self._comp._postprocess_colormap,
                 use_wls_filter=self._comp._use_wls_filter,
                 wls_level=self._comp._wls_level,
                 wls_lambda=self._comp._wls_lambda,
@@ -293,13 +308,13 @@ class StereoComponent(Component):
 
             if self._comp._encoderProfile == dai.VideoEncoderProperties.Profile.MJPEG:
                 out = XoutMjpeg(frames=StreamXout(self._comp.encoder.id, self._comp.encoder.bitstream),
-                                color=False,
+                                color=self._comp.colormap is not None,
                                 lossless=self._comp.encoder.getLossless(),
                                 fps=self._comp.encoder.getFrameRate(),
                                 frame_shape=(1200, 800))
             else:
                 out = XoutH26x(frames=StreamXout(self._comp.encoder.id, self._comp.encoder.bitstream),
-                               color=False,
+                               color=self._comp.colormap is not None,
                                profile=self._comp._encoderProfile,
                                fps=self._comp.encoder.getFrameRate(),
                                frame_shape=(1200, 800))

--- a/depthai_sdk/src/depthai_sdk/components/stereo_component.py
+++ b/depthai_sdk/src/depthai_sdk/components/stereo_component.py
@@ -33,8 +33,7 @@ class StereoComponent(Component):
                  replay: Optional[Replay] = None,
                  args: Any = None,
                  name: Optional[str] = None,
-                 encode: Union[None, str, bool, dai.VideoEncoderProperties.Profile] = None,
-                 colormap: Optional[dai.Colormap] = None):
+                 encode: Union[None, str, bool, dai.VideoEncoderProperties.Profile] = None):
         """
         Args:
             pipeline (dai.Pipeline): DepthAI pipeline
@@ -46,7 +45,6 @@ class StereoComponent(Component):
             args (Any, optional): Use user defined arguments when constructing the pipeline
             name (str, optional): Name of the output stream
             encode (str/bool/Profile, optional): Encode the output stream
-            colormap (dai.Colormap, optional): Colormap to apply to the output stream
         """
         super().__init__()
         self.out = self.Out(self)
@@ -57,7 +55,7 @@ class StereoComponent(Component):
         self._left_stream: dai.Node.Output
         self._right_stream: dai.Node.Output
 
-        self.colormap = colormap
+        self.colormap = None
 
         self._replay: Optional[Replay] = replay
         self._resolution: Optional[Union[str, dai.MonoCameraProperties.SensorResolution]] = resolution

--- a/depthai_sdk/src/depthai_sdk/components/stereo_component.py
+++ b/depthai_sdk/src/depthai_sdk/components/stereo_component.py
@@ -55,7 +55,7 @@ class StereoComponent(Component):
         self._left_stream: dai.Node.Output
         self._right_stream: dai.Node.Output
 
-        self.colormap = None
+        self.colormap = dai.Colormap.STEREO_TURBO
 
         self._replay: Optional[Replay] = replay
         self._resolution: Optional[Union[str, dai.MonoCameraProperties.SensorResolution]] = resolution

--- a/depthai_sdk/src/depthai_sdk/components/stereo_component.py
+++ b/depthai_sdk/src/depthai_sdk/components/stereo_component.py
@@ -55,7 +55,7 @@ class StereoComponent(Component):
         self._left_stream: dai.Node.Output
         self._right_stream: dai.Node.Output
 
-        self.colormap = dai.Colormap.STEREO_TURBO
+        self.colormap = None
 
         self._replay: Optional[Replay] = replay
         self._resolution: Optional[Union[str, dai.MonoCameraProperties.SensorResolution]] = resolution

--- a/depthai_sdk/src/depthai_sdk/oak_camera.py
+++ b/depthai_sdk/src/depthai_sdk/oak_camera.py
@@ -175,8 +175,7 @@ class OakCamera:
                       left: Union[None, dai.Node.Output, CameraComponent] = None,  # Left mono camera
                       right: Union[None, dai.Node.Output, CameraComponent] = None,  # Right mono camera
                       name: Optional[str] = None,
-                      encode: Union[None, str, bool, dai.VideoEncoderProperties.Profile] = None,
-                      colormap: dai.Colormap = None
+                      encode: Union[None, str, bool, dai.VideoEncoderProperties.Profile] = None
                       ) -> StereoComponent:
         """
         Create Stereo camera component. If left/right cameras/component aren't specified they will get created internally.
@@ -188,7 +187,6 @@ class OakCamera:
             right (CameraComponent/dai.node.MonoCamera): Pass the camera object (component/node) that will be used for stereo camera.
             name (str): Name used to identify the X-out stream. This name will also be associated with the frame in the callback function.
             encode (bool/str/Profile): Whether we want to enable video encoding (accessible via StereoComponent.out.encoded). If True, it will use h264 codec.
-            colormap (dai.Colormap): Colormap to be applied to the depth map. If None, no colormap will be applied.
         """
         comp = StereoComponent(self._pipeline,
                                resolution=resolution,
@@ -198,8 +196,7 @@ class OakCamera:
                                replay=self.replay,
                                args=self._args,
                                name=name,
-                               encode=encode,
-                               colormap=colormap)
+                               encode=encode)
         self._components.append(comp)
         return comp
 

--- a/depthai_sdk/src/depthai_sdk/oak_camera.py
+++ b/depthai_sdk/src/depthai_sdk/oak_camera.py
@@ -175,7 +175,8 @@ class OakCamera:
                       left: Union[None, dai.Node.Output, CameraComponent] = None,  # Left mono camera
                       right: Union[None, dai.Node.Output, CameraComponent] = None,  # Right mono camera
                       name: Optional[str] = None,
-                      encode: Union[None, str, bool, dai.VideoEncoderProperties.Profile] = None
+                      encode: Union[None, str, bool, dai.VideoEncoderProperties.Profile] = None,
+                      colormap: dai.Colormap = None
                       ) -> StereoComponent:
         """
         Create Stereo camera component. If left/right cameras/component aren't specified they will get created internally.
@@ -187,6 +188,7 @@ class OakCamera:
             right (CameraComponent/dai.node.MonoCamera): Pass the camera object (component/node) that will be used for stereo camera.
             name (str): Name used to identify the X-out stream. This name will also be associated with the frame in the callback function.
             encode (bool/str/Profile): Whether we want to enable video encoding (accessible via StereoComponent.out.encoded). If True, it will use h264 codec.
+            colormap (dai.Colormap): Colormap to be applied to the depth map. If None, no colormap will be applied.
         """
         comp = StereoComponent(self._pipeline,
                                resolution=resolution,
@@ -196,7 +198,8 @@ class OakCamera:
                                replay=self.replay,
                                args=self._args,
                                name=name,
-                               encode=encode)
+                               encode=encode,
+                               colormap=colormap)
         self._components.append(comp)
         return comp
 


### PR DESCRIPTION
Usage:
```python
import depthai as dai

from depthai_sdk import OakCamera

with OakCamera() as oak:
    stereo = oak.create_stereo('800p', fps=30, encode='h264')
    stereo.set_colormap(dai.Colormap.STEREO_TURBO)
    oak.visualize(stereo.out.encoded)
    oak.start(blocking=True)

```