### PR TITLE
Refactored how pipeline is being built

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "depthai_sdk/src/depthai_sdk/components/integrations/depthai_pipeline_graph"]
-	path = depthai_sdk/src/depthai_sdk/components/integrations/depthai_pipeline_graph
+[submodule "depthai_sdk/src/depthai_sdk/integrations/depthai_pipeline_graph"]
+	path = depthai_sdk/src/depthai_sdk/integrations/depthai_pipeline_graph
 	url = https://github.com/luxonis/depthai_pipeline_graph

--- a/depthai_sdk/examples/CameraComponent/preview_all_cameras.py
+++ b/depthai_sdk/examples/CameraComponent/preview_all_cameras.py
@@ -1,0 +1,7 @@
+from depthai_sdk import OakCamera
+
+with OakCamera() as oak:
+    cams = oak.create_all_cameras()
+
+    oak.visualize(cams)
+    oak.start(blocking=True)

--- a/depthai_sdk/examples/CameraComponent/preview_all_cameras.py
+++ b/depthai_sdk/examples/CameraComponent/preview_all_cameras.py
@@ -2,6 +2,5 @@ from depthai_sdk import OakCamera
 
 with OakCamera() as oak:
     cams = oak.create_all_cameras()
-
     oak.visualize(cams)
     oak.start(blocking=True)

--- a/depthai_sdk/examples/mixed/switch_between_models.py
+++ b/depthai_sdk/examples/mixed/switch_between_models.py
@@ -1,0 +1,54 @@
+from depthai_sdk import OakCamera
+from depthai_sdk.classes.packets import DetectionPacket
+import depthai as dai
+import cv2
+
+# We use callback, so we only have cv2 window for all models
+def cb(packet: DetectionPacket):
+    frame = packet.visualizer.draw(packet.frame)
+    cv2.imshow('Frame', frame)
+
+with OakCamera() as oak:
+    color = oak.create_camera('color')
+
+    script = oak.pipeline.create(dai.node.Script)
+    # When Script node receives a message from the host it will switch streaming frames to another NN model
+    script.setScript("""
+    i = 0
+    outputs = ['out1', 'out2']
+
+    while True:
+        frame = node.io['frames'].get()
+
+        switch = node.io['switch'].tryGet()
+        if switch is not None:
+            i += 1
+            if len(outputs) <= i:
+                i = 0
+
+        node.io[outputs[i]].send(frame)    
+    """)
+    color.stream.link(script.inputs['frames'])
+
+    # We can have multiple models here, not just 2 object detection models
+    nn1 = oak.create_nn('yolov6nr3_coco_640x352', input=script.outputs['out1'])
+    nn2 = oak.create_nn('mobilenet-ssd', input=script.outputs['out2'])
+    # We will send "switch" message via XLinkIn
+    xin = oak.pipeline.create(dai.node.XLinkIn)
+    xin.setStreamName('switch')
+    xin.out.link(script.inputs['switch'])
+
+    oak.visualize([nn1, nn2], fps=True, callback=cb)
+
+    # oak.show_graph()
+
+    oak.start()
+    qin = oak.device.getInputQueue('switch')
+
+    while True:
+        key = oak.poll()
+        if key == ord('s'):
+            print('Switching NN model')
+            qin.send(dai.Buffer())
+        elif key == ord('q'):
+            break

--- a/depthai_sdk/requirements.txt
+++ b/depthai_sdk/requirements.txt
@@ -5,7 +5,7 @@ blobconverter>=1.2.8
 pytube>=12.1.0
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/
 # This specific commit is needed for the debug mode (oak.show_graph()). TODO: update when depthai has new release
-depthai>=2.20.1.0
+depthai>=2.20.2.0
 PyTurboJPEG==1.6.4
 marshmallow==3.17.0
 distinctipy

--- a/depthai_sdk/requirements.txt
+++ b/depthai_sdk/requirements.txt
@@ -4,8 +4,7 @@ opencv-contrib-python>4
 blobconverter>=1.2.8
 pytube>=12.1.0
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/
-# This specific commit is needed for the debug mode (oak.show_graph()). TODO: update when depthai has new release
-depthai>=2.20.2.0
+depthai==2.20.2.0.dev+6f79483e1e58a441c942101092681466ae8961fb
 PyTurboJPEG==1.6.4
 marshmallow==3.17.0
 distinctipy

--- a/depthai_sdk/src/depthai_sdk/components/camera_helper.py
+++ b/depthai_sdk/src/depthai_sdk/components/camera_helper.py
@@ -4,61 +4,32 @@ from typing import *
 import numpy as np
 import cv2
 
-class ImageSensor:
-    name: str
-    resolutions: List[Union[
-        dai.ColorCameraProperties.SensorResolution,
-        dai.MonoCameraProperties.SensorResolution
-    ]]
-    type: dai.node
 
-    def __eq__(self, other):
-        return self.name == other
-
-    def __init__(self,
-                 name: str,
-                 resolutions: List[str],
-                 type: str):
-        from .parser import parse_resolution
-        self.name = name
-        self.type = dai.node.ColorCamera if type == 'color' else dai.node.MonoCamera
-        self.resolutions = [parse_resolution(self.type, resolution) for resolution in resolutions]
-
-    @property
-    def maxRes(self) -> Union[dai.ColorCameraProperties.SensorResolution, dai.MonoCameraProperties.SensorResolution]:
-        return self.resolutions[0]
-
-
-cameraSensors: List[ImageSensor] = [
-    ImageSensor('IMX378', ['12mp', '4k', '1080p'], 'color'),
-    ImageSensor('OV9282', ['800P', '720p', '400p'], 'mono'),
-    ImageSensor('OV9782', ['800P', '720p', '400p'], 'color'),
-    ImageSensor('OV9281', ['800P', '720p', '400p'], 'color'),
-    ImageSensor('IMX214', ['13mp', '12mp', '4k', '1080p'], 'color'),
-    ImageSensor('OV7750', ['480P', '400p'], 'mono'),
-    ImageSensor('OV7251', ['480P', '400p'], 'mono'),
-    ImageSensor('IMX477', ['12mp', '4k', '1080p'], 'color'),
-    ImageSensor('IMX577', ['12mp', '4k', '1080p'], 'color'),
-    ImageSensor('AR0234', ['1200P'], 'color'),
-    ImageSensor('IMX582', ['48mp', '12mp', '4k'], 'color'),
-]
-
-cameraResolutions: Dict[Any, Tuple[int, int]] = {
-    dai.ColorCameraProperties.SensorResolution.THE_13_MP: (4208, 3120),
-    dai.ColorCameraProperties.SensorResolution.THE_12_MP: (4056, 3040),
-    dai.ColorCameraProperties.SensorResolution.THE_4_K: (3840, 2160),
-    dai.ColorCameraProperties.SensorResolution.THE_1200_P: (1920, 1200),
-    dai.ColorCameraProperties.SensorResolution.THE_1080_P: (1920, 1080),
-    dai.ColorCameraProperties.SensorResolution.THE_800_P: (1280, 800),
-    dai.ColorCameraProperties.SensorResolution.THE_720_P: (1280, 720),
-
-    dai.MonoCameraProperties.SensorResolution.THE_800_P: (1280, 800),
+monoResolutions: Dict[dai.MonoCameraProperties.SensorResolution, Tuple[int,int]] = {
+    dai.MonoCameraProperties.SensorResolution.THE_1200_P: (1920, 1200), # Monochrome AR0234
+    dai.MonoCameraProperties.SensorResolution.THE_800_P: (1280, 800), # OV9282
     dai.MonoCameraProperties.SensorResolution.THE_720_P: (1280, 720),
-    dai.MonoCameraProperties.SensorResolution.THE_480_P: (640, 480),
+    dai.MonoCameraProperties.SensorResolution.THE_480_P: (640, 480), # OV7251
     dai.MonoCameraProperties.SensorResolution.THE_400_P: (640, 400),
 }
 
+colorResolutions: Dict[dai.ColorCameraProperties.SensorResolution, Tuple[int,int]] = {
+    dai.ColorCameraProperties.SensorResolution.THE_5312X6000: (5312, 6000),  # IMX582 cropped
+    dai.ColorCameraProperties.SensorResolution.THE_13_MP: (4208, 3120),  # AR214
+    dai.ColorCameraProperties.SensorResolution.THE_12_MP: (4056, 3040),  # IMX378, IMX477, IMX577
+    dai.ColorCameraProperties.SensorResolution.THE_4000X3000: (4000, 3000),  # IMX582 with binning enabled
+    dai.ColorCameraProperties.SensorResolution.THE_4_K: (3840, 2160),
+    dai.ColorCameraProperties.SensorResolution.THE_1200_P: (1920, 1200),  # AR0234
+    dai.ColorCameraProperties.SensorResolution.THE_1080_P: (1920, 1080),
+    dai.ColorCameraProperties.SensorResolution.THE_1440X1080: (1440, 1080),
+    dai.ColorCameraProperties.SensorResolution.THE_5_MP: (2592, 1944),  # OV5645
+    dai.ColorCameraProperties.SensorResolution.THE_800_P: (1280, 800),  # OV9782
+    dai.ColorCameraProperties.SensorResolution.THE_720_P: (1280, 720),
+}
 
+sensorResolutions: Dict[Any, Tuple[int,int]] = []
+sensorResolutions.extend(monoResolutions)
+sensorResolutions.extend(colorResolutions)
 
 def availableIspScales() -> List[Tuple[int, Tuple[int, int]]]:
     """
@@ -195,36 +166,21 @@ def setCameraControl(control: dai.CameraControl,
     # TODO: Add contrast, exposure compensation, brightness, manual exposure, and saturation
 
 
-def cameraSensor(sensorName: str) -> ImageSensor:
-    return cameraSensors[cameraSensors.index(sensorName.upper())]
+def get_sensor_resolution(type: dai.CameraSensorType, width: int, height: int) -> Tuple[Union[dai.ColorCameraProperties.SensorResolution, dai.MonoCameraProperties.SensorResolution], Tuple[int,int]]:
+    def get_res(resolutions: Dict[Any, Tuple[int,int]]):
+        for res, (w, h) in resolutions.items():
+            if width == w and height == h:
+                return (res, (w,h))
 
+    if type == dai.CameraSensorType.COLOR:
+        return get_res(colorResolutions)
+    elif type == dai.CameraSensorType.MONO:
+        return get_res(monoResolutions)
+    else:
+        raise Exception('Camera sensor type unknown!', type)
 
-def cameraSensorType(sensorName: str) -> dai.node:
-    """
-    Gets camera sensor type from it's name, either MonoCamera or ColorCamera.
-    @param sensorName: Name of the camera sensor
-    @return: dai.node.MonoCamera or dai.node.ColorCamera
-    """
-    return cameraSensor(sensorName).type
-
-
-def cameraSensorResolution(sensorName: str
-                           ) -> Union[
-    dai.ColorCameraProperties.SensorResolution, dai.MonoCameraProperties.SensorResolution]:
-    """
-    Gets camera sensor type from it's name, either MonoCamera or ColorCamera.
-    @param sensorName: Name of the camera sensor
-    @return: dai.node.MonoCamera or dai.node.ColorCamera
-    """
-    return cameraSensor(sensorName).maxRes
-
-
-def cameraSensorResolutionSize(sensorName: str) -> Tuple[int, int]:
-    res = cameraSensorResolution(sensorName)
-    return cameraResolutions[res]
-
-
-def getClosesResolution(sensorName: str,
+def getClosesResolution(sensor: dai.CameraFeatures,
+                        type: dai.CameraSensorType,
                         width: Optional[int] = None,
                         height: Optional[int] = None, ):
     if width and height:
@@ -235,8 +191,10 @@ def getClosesResolution(sensorName: str,
     minError = 99999
     closestRes = None
     desired, i = (width, 0) if width else (height, 1)
-    for res in cameraSensor(sensorName).resolutions:
-        size = cameraResolutions[res]
+
+    resolutions = [get_sensor_resolution(type, conf.width, conf.height) for conf in sensor.configs if conf.type == type]
+
+    for (res, size) in resolutions:
         err = abs(size[i] - desired)
         if err < minError:
             minError = err

--- a/depthai_sdk/src/depthai_sdk/components/component.py
+++ b/depthai_sdk/src/depthai_sdk/components/component.py
@@ -19,13 +19,6 @@ class Component(ABC):
         """
         return None
 
-    @abstractmethod
-    def on_init(self, pipeline: dai.Pipeline, device: dai.Device, version: dai.OpenVINO.Version):
-        """
-        This function will be called after the app connects to the Device
-        """
-        raise NotImplementedError("Every component needs to include 'updateDeviceInfo()' method!")
-
     def _stream_name_ok(self, pipeline: dai.Pipeline, name: str) -> bool:
         # Check if there's already an XLinkOut stream with this name
         for node in pipeline.getAllNodes():

--- a/depthai_sdk/src/depthai_sdk/components/imu_component.py
+++ b/depthai_sdk/src/depthai_sdk/components/imu_component.py
@@ -8,7 +8,9 @@ from depthai_sdk.oak_outputs.xout.xout_imu import XoutIMU
 
 
 class IMUComponent(Component):
-    def __init__(self, pipeline: dai.Pipeline):
+    def __init__(self,
+                 device: dai.Device,
+                 pipeline: dai.Pipeline):
         self.out = self.Out(self)
 
         super().__init__()
@@ -42,9 +44,6 @@ class IMUComponent(Component):
         self.node.setBatchReportThreshold(batchReportThreshold=batch_report_threshold)
         self.node.setMaxBatchReports(maxBatchReports=max_batch_reports)
         self.node.enableFirmwareUpdate(enable_firmware_update)
-
-    def on_init(self, pipeline: dai.Pipeline, device: dai.Device, version: dai.OpenVINO.Version):
-        pass
 
     class Out:
         def __init__(self, imu_component: 'IMUComponent'):

--- a/depthai_sdk/src/depthai_sdk/components/nn_component.py
+++ b/depthai_sdk/src/depthai_sdk/components/nn_component.py
@@ -30,7 +30,7 @@ class NNComponent(Component):
                  device: dai.Device,
                  pipeline: dai.Pipeline,
                  model: Union[str, Path, Dict],  # str for SDK supported model or Path to custom model's json
-                 input: Union[CameraComponent, 'NNComponent'],
+                 input: Union[CameraComponent, 'NNComponent', dai.Node.Output],
                  nn_type: Optional[str] = None,  # Either 'yolo' or 'mobilenet'
                  decode_fn: Optional[Callable] = None,
                  tracker: bool = False,  # Enable object tracker - only for Object detection models
@@ -48,7 +48,7 @@ class NNComponent(Component):
 
         Args:
             model (Union[str, Path, Dict]): str for SDK supported model / Path to blob or custom model's json
-            input: (Union[Component, dai.Node.Output]): Input to the NN. If nn_component that is object detector, crop HQ frame at detections (Script node + ImageManip node)
+            input: (Union[Component, dai.Node.Output, dai.Node.Output]): Input to the NN. If nn_component that is object detector, crop HQ frame at detections (Script node + ImageManip node)
             nn_type (str, optional): Type of the NN - Either 'Yolo' or 'MobileNet'
             tracker (bool, default False): Enable object tracker - only for Object detection models
             spatial (bool, default False): Enable getting Spatial coordinates (XYZ), only for Obj detectors. Yolo/SSD use on-device spatial calc, others on-host (gen2-calc-spatials-on-host)
@@ -76,13 +76,13 @@ class NNComponent(Component):
 
         # Private properties
         self._ar_resize_mode: ResizeMode = ResizeMode.LETTERBOX  # Default
-        self._input: Union[CameraComponent, 'NNComponent']  # Input to the NNComponent node passed on initialization
+        self._input: Union[CameraComponent, 'NNComponent', dai.Node.Output] = input # Input to the NNComponent node passed on initialization
         self._stream_input: dai.Node.Output  # Node Output that will be used as the input for this NNComponent
 
         self._blob: Optional[dai.OpenVINO.Blob] = None
         self._forced_version: Optional[dai.OpenVINO.Version] = None  # Forced OpenVINO version
         self._size: Optional[Tuple[int, int]] = None  # Input size to the NN
-        self._args: Optional[Dict] = None
+        self._args: Optional[Dict] = args
         self._config: Optional[Dict] = None
         self._node_type: dai.node = dai.node.NeuralNetwork  # Type of the node for `node`
         self._roboflow: Optional[RoboflowIntegration] = None
@@ -94,18 +94,14 @@ class NNComponent(Component):
 
         self._input_queue = Optional[None]  # Input queue for multi-stage pipeline
 
-        self._spatial: Optional[Union[bool, StereoComponent]] = None
-        self._replay: Optional[Replay]  # Replay module
+        self._spatial: Optional[Union[bool, StereoComponent]] = spatial
+        self._replay: Optional[Replay] = replay  # Replay module
 
         # For visualizer
         self._labels: Optional[List] = None  # Obj detector labels
         self._handler: Optional[Callable] = None  # Custom model handler for decoding
 
         # Save passed settings
-        self._input = input
-        self._spatial = spatial
-        self._args = args
-        self._replay = replay
         self._decode_fn = decode_fn or None  # Decode function that will be used to decode NN results
 
         # Parse passed settings
@@ -190,6 +186,9 @@ class NNComponent(Component):
 
                 self.image_manip.out.link(self.node.input)
                 self.node.input.setQueueSize(20)
+        elif isinstance(self._input, dai.Node.Output):
+            self._stream_input = self._input
+            self._setup_resize_manip(pipeline).link(self.node.input)
         else:
             raise ValueError(
                 "'input' argument passed on init isn't supported!"
@@ -604,9 +603,9 @@ class NNComponent(Component):
                                    input_queue_name="input_queue" if self._comp.x_in else None)
             else:
                 det_nn_out = StreamXout(id=self._comp.node.id, out=self._comp.node.out, name=self._comp.name)
-
+                input_stream = self._comp._stream_input
                 out = XoutNnResults(det_nn=self._comp,
-                                    frames=self._comp._input.get_stream_xout(),
+                                    frames=StreamXout(id=input_stream.getParent().id, out=input_stream, name=self._comp.name),
                                     nn_results=det_nn_out)
 
             return self._comp._create_xout(pipeline, out)

--- a/depthai_sdk/src/depthai_sdk/components/parser.py
+++ b/depthai_sdk/src/depthai_sdk/components/parser.py
@@ -70,7 +70,10 @@ def parse_bool(value: str) -> bool:
         raise ValueError(f"Couldn't parse '{value}' to bool!")
 
 
-def parse_camera_socket(value: str) -> dai.CameraBoardSocket:
+def parse_camera_socket(value: Union[str, dai.CameraBoardSocket]) -> dai.CameraBoardSocket:
+    if isinstance(value, dai.CameraBoardSocket):
+        return value
+
     value = value.upper()
     if value in ["COLOR", "RGB", "CENTER", "CAMA", "CAM_A", "CAM-A"]:
         return dai.CameraBoardSocket.CAM_A

--- a/depthai_sdk/src/depthai_sdk/components/parser.py
+++ b/depthai_sdk/src/depthai_sdk/components/parser.py
@@ -78,8 +78,6 @@ def parse_camera_socket(value: str) -> dai.CameraBoardSocket:
         return dai.CameraBoardSocket.CAM_B
     elif value in ["RIGHT", "CAMC", "CAM_C", "CAM-C"]:
         return dai.CameraBoardSocket.CAM_C
-    elif value in ["RIGHT", "CAMC", "CAM_C", "CAM-C"]:
-        return dai.CameraBoardSocket.CAM_C
     elif value in ["CAMD", "CAM_D", "CAM-D"]:
         return dai.CameraBoardSocket.CAM_D
     elif value in ["CAME", "CAM_E", "CAM-E"]:

--- a/depthai_sdk/src/depthai_sdk/oak_outputs/xout/xout_nn.py
+++ b/depthai_sdk/src/depthai_sdk/oak_outputs/xout/xout_nn.py
@@ -90,7 +90,6 @@ class XoutNnResults(XoutSeqSync, XoutFrames):
         if self._frame_shape is None:
             # Lazy-load the frame shape
             self._frame_shape = np.array([packet.frame.shape[0], packet.frame.shape[1]])
-            print(self._frame_shape)
 
         if self._visualizer:
             self._visualizer.frame_shape = self._frame_shape

--- a/depthai_sdk/src/depthai_sdk/oak_outputs/xout/xout_nn.py
+++ b/depthai_sdk/src/depthai_sdk/oak_outputs/xout/xout_nn.py
@@ -60,12 +60,19 @@ class XoutNnResults(XoutSeqSync, XoutFrames):
                 self.labels.append((text, color))
 
         self.normalizer = NormalizeBoundingBox(det_nn._size, det_nn._ar_resize_mode)
-        try:
-            self._frame_shape = self.det_nn._input.node.getPreviewSize()
-        except AttributeError:
-            self._frame_shape = self.det_nn._input.stream_size  # Replay
 
-        self._frame_shape = np.array(self._frame_shape)[::-1]
+        self._frame_shape = None
+        if isinstance(self.det_nn._input, dai.Node.Output):
+            pass # No good way to get size of dai.Node.Output. We will set it on first received frame
+        else: # CameeraComponent / NNComponent
+            if isinstance(self.det_nn._input.node, dai.node.ColorCamera):
+                self._frame_shape = self.det_nn._input.node.getPreviewSize()
+            elif isinstance(self.det_nn._input.node, dai.node.MonoCamera):
+                self._frame_shape = self.det_nn._input.node.getResolutionSize()
+            elif isinstance(self.det_nn._input.node, dai.node.XLinkIn): # Replay
+                self._frame_shape = self.det_nn._input.stream_size
+            # [width, height] to [height, width]
+            self._frame_shape = np.array(self._frame_shape)[::-1]
 
         self.segmentation_colormap = None
 
@@ -76,6 +83,15 @@ class XoutNnResults(XoutSeqSync, XoutFrames):
         super().setup_visualize(visualizer, visualizer_enabled, name)
 
     def on_callback(self, packet: Union[DetectionPacket, TrackerPacket]):
+        # Convert Grayscale to BGR
+        if len(packet.frame.shape) == 2:
+            packet.frame = np.dstack((packet.frame, packet.frame, packet.frame))
+
+        if self._frame_shape is None:
+            # Lazy-load the frame shape
+            self._frame_shape = np.array([packet.frame.shape[0], packet.frame.shape[1]])
+            print(self._frame_shape)
+
         if self._visualizer:
             self._visualizer.frame_shape = self._frame_shape
 


### PR DESCRIPTION
- Refactored component creation, so we have device/pipeline on component creation already
- ^ allows getting available camera sensors on device and their resolutions. Now SDK supports OAK-D-LR / OAK-D-SR
- Added oak.create_all_cameras() function, creates List[CameraComponent] for each camera sensor on the OAK cam, example code below
- Added support so NNComponent accepts node output as an input