### PR TITLE
Fix frame recording

### DIFF
--- a/depthai_sdk/src/depthai_sdk/oak_camera.py
+++ b/depthai_sdk/src/depthai_sdk/oak_camera.py
@@ -299,6 +299,7 @@ class OakCamera:
         for out in self._out_templates:
             if isinstance(out, RecordConfig):
                 out.rec.close()
+        self._oak.close()
 
     def start(self, blocking=False):
         """

--- a/depthai_sdk/src/depthai_sdk/oak_device.py
+++ b/depthai_sdk/src/depthai_sdk/oak_device.py
@@ -45,3 +45,7 @@ class OakDevice:
 
     def set_max_queue_size(self, size: int):
         self.max_queue_size = size
+
+    def close(self):
+        for stream in self.oak_out_streams:
+            stream.close()

--- a/depthai_sdk/src/depthai_sdk/oak_outputs/xout/xout_base.py
+++ b/depthai_sdk/src/depthai_sdk/oak_outputs/xout/xout_base.py
@@ -70,6 +70,12 @@ class XoutBase(ABC):
         """
         pass
 
+    def close(self) -> None:
+        """
+        Hook that will be called when exiting the context manager.
+        """
+        pass
+
     # This approach is used as some functions (eg. imshow()) need to be called from
     # main thread, and calling them from callback thread wouldn't work.
     def check_queue(self, block=False) -> None:

--- a/depthai_sdk/src/depthai_sdk/oak_outputs/xout/xout_frames.py
+++ b/depthai_sdk/src/depthai_sdk/oak_outputs/xout/xout_frames.py
@@ -100,6 +100,6 @@ class XoutFrames(XoutBase):
 
         self.queue.put(packet, block=False)
 
-    def __del__(self):
+    def close(self):
         if self._video_recorder:
             self._video_recorder.close()


### PR DESCRIPTION
Inside `XoutFrames`, when called `__del__`, self._video_recorder was always None, so it didn't properly close the .mp4 video file and it was invalid (video players failed). I guess GC did its thing beforehand.
```
    def __del__(self):
        if self._video_recorder:
```
TODO: Fix recording both right + stereo, currently right isn't recorded:
```
with OakCamera() as oak:
    left = oak.create_camera('left', resolution='800p')
    right = oak.create_camera('right', resolution='800p')
    stereo = oak.create_stereo(left=left, right=right)
    oak.visualize(stereo.out.disparity, record_path='stereo.mp4')
    oak.visualize(right, record_path='right.mp4')
    oak.start(blocking=True)