### PR TITLE
Control camera with NN results

### DIFF
--- a/depthai_sdk/examples/CameraComponent/camera_control_with_nn.py
+++ b/depthai_sdk/examples/CameraComponent/camera_control_with_nn.py
@@ -1,0 +1,10 @@
+from depthai_sdk import OakCamera
+
+with OakCamera() as oak:
+    color = oak.create_camera('color')
+    face_det = oak.create_nn('face-detection-retail-0004', color)
+    # Control the camera's exposure/focus based on the (largest) detected face
+    color.control_with_nn(face_det, auto_focus=True, auto_exposure=True, debug=False)
+
+    oak.visualize(face_det, fps=True)
+    oak.start(blocking=True)

--- a/depthai_sdk/src/depthai_sdk/classes/output_config.py
+++ b/depthai_sdk/src/depthai_sdk/classes/output_config.py
@@ -16,10 +16,21 @@ from depthai_sdk.trigger_action.trigger_action import TriggerAction
 from depthai_sdk.trigger_action.triggers.abstract_trigger import Trigger
 from depthai_sdk.visualize.visualizer import Visualizer
 
+def find_new_name(name: str, names: List[str]):
+    while True:
+        arr = name.split(' ')
+        num = arr[-1]
+        if num.isnumeric():
+            arr[-1] = str(int(num) + 1)
+            name = " ".join(arr)
+        else:
+            name = f"{name} 2"
+        if name not in names:
+            return name
 
 class BaseConfig:
     @abstractmethod
-    def setup(self, pipeline: dai.Pipeline, device, names: List[str]) -> List[XoutBase]:
+    def setup(self, pipeline: dai.Pipeline, device: dai.Device, names: List[str]) -> List[XoutBase]:
         raise NotImplementedError()
 
 
@@ -39,24 +50,12 @@ class OutputConfig(BaseConfig):
         self.visualizer_enabled = visualizer_enabled
         self.record_path = record_path
 
-    def find_new_name(self, name: str, names: List[str]):
-        while True:
-            arr = name.split(' ')
-            num = arr[-1]
-            if num.isnumeric():
-                arr[-1] = str(int(num) + 1)
-                name = " ".join(arr)
-            else:
-                name = f"{name} 2"
-            if name not in names:
-                return name
-
     def setup(self, pipeline: dai.Pipeline, device, names: List[str]) -> List[XoutBase]:
         xoutbase: XoutBase = self.output(pipeline, device)
         xoutbase.setup_base(self.callback)
 
         if xoutbase.name in names:  # Stream name already exist, append a number to it
-            xoutbase.name = self.find_new_name(xoutbase.name, names)
+            xoutbase.name = find_new_name(xoutbase.name, names)
         names.append(xoutbase.name)
 
         recorder = None

--- a/depthai_sdk/src/depthai_sdk/components/camera_helper.py
+++ b/depthai_sdk/src/depthai_sdk/components/camera_helper.py
@@ -179,6 +179,18 @@ def get_sensor_resolution(type: dai.CameraSensorType, width: int, height: int) -
     else:
         raise Exception('Camera sensor type unknown!', type)
 
+def get_resolution_size(
+        resolution: Union[
+            dai.ColorCameraProperties.SensorResolution,
+            dai.MonoCameraProperties.SensorResolution
+            ]) -> Tuple[int,int]:
+    if resolution in colorResolutions:
+        return colorResolutions[resolution]
+    elif resolution in monoResolutions:
+        return monoResolutions[resolution]
+    else:
+        raise Exception('Camera sensor resolution unknown!', resolution)
+
 def getClosesResolution(sensor: dai.CameraFeatures,
                         type: dai.CameraSensorType,
                         width: Optional[int] = None,

--- a/depthai_sdk/src/depthai_sdk/components/control_camera_with_nn.py
+++ b/depthai_sdk/src/depthai_sdk/components/control_camera_with_nn.py
@@ -1,0 +1,69 @@
+import depthai as dai
+from depthai_sdk.classes.enum import ResizeMode
+from typing import Union, Tuple
+from depthai_sdk.components.camera_helper import get_resolution_size
+from pathlib import Path
+from string import Template
+
+def control_camera_with_nn(
+        pipeline: dai.Pipeline,
+        camera_control: dai.Node.Input,
+        nn_output: dai.Node.Output,
+        resize_mode: ResizeMode,
+        resolution: Union[dai.ColorCameraProperties.SensorResolution, dai.MonoCameraProperties.SensorResolution],
+        nn_size: Tuple[int, int],
+        af: bool,
+        ae: bool,
+        debug: bool
+        ):
+    sensor_resolution = get_resolution_size(resolution)
+    # width / height (old ar)
+    sensor_ar = sensor_resolution[0] / sensor_resolution[1]
+    # NN ar (new ar)
+    nn_ar = nn_size[0] / nn_size[1]
+
+    if resize_mode == ResizeMode.LETTERBOX:
+        padding = (sensor_ar - nn_ar) / 2
+        if padding > 0:
+            init = f"xmin = 0; ymin = {-padding}; xmax = 1; ymax = {1 + padding}"
+        else:
+            init = f"xmin = {padding}; ymin = 0; xmax = {1 - padding}; ymax = 1"
+    elif resize_mode in [ResizeMode.CROP, ResizeMode.FULL_CROP]:
+        cropping = (1 - (nn_ar / sensor_ar)) / 2
+        if cropping < 0:
+            init = f"xmin = 0; ymin = {-cropping}; xmax = 1; ymax = {1 + cropping}"
+        else:
+            init = f"xmin = {cropping}; ymin = 0; xmax = {1 - cropping}; ymax = 1"
+    else: # Stretch
+        init = f"xmin=0; ymin=0; xmax=1; ymax=1"
+
+
+    resize_str = f"new_xmin=xmin+width*det.xmin; new_ymin=ymin+height*det.ymin; new_xmax=xmin+width*det.xmax; new_ymax=ymin+height*det.ymax;"
+    denormalize = f"startx=int(new_xmin*{sensor_resolution[0]}); starty=int(new_ymin*{sensor_resolution[1]}); new_width=int((new_xmax-new_xmin)*{sensor_resolution[0]}); new_height=int((new_ymax-new_ymin)*{sensor_resolution[1]});"
+    control_str = ''
+    if ae:
+        control_str += f"control.setAutoExposureRegion(startx, starty, new_width, new_height);"
+    if af:
+        control_str += f"control.setAutoFocusRegion(startx, starty, new_width, new_height);"
+
+
+    script_node = pipeline.create(dai.node.Script)
+    script_node.setProcessor(dai.ProcessorType.LEON_CSS)  # More stable
+
+    with open(Path(__file__).parent / 'template_control_cam_with_nn.py', 'r') as file:
+        code = Template(file.read()).substitute(
+            DEBUG='' if debug else '#',
+            INIT=init,
+            RESIZE=resize_str,
+            DENORMALIZE=denormalize,
+            CONTROL=control_str
+        )
+        script_node.setScript(code)
+
+        if debug:
+            print(code)
+
+    # Node linking:
+    # NN output -> Script -> Camera input
+    nn_output.link(script_node.inputs['detections'])
+    script_node.outputs['control'].link(camera_control)

--- a/depthai_sdk/src/depthai_sdk/components/template_control_cam_with_nn.py
+++ b/depthai_sdk/src/depthai_sdk/components/template_control_cam_with_nn.py
@@ -1,0 +1,27 @@
+${INIT}
+width=xmax-xmin; height=ymax-ymin;
+while True:
+    detections = node.io['detections'].get()
+    if len(detections.detections) == 0:
+        continue
+    largest_det = detections.detections[0]
+    largest_size = 0
+    for det in detections.detections:
+        size = (det.xmax - det.xmin) * (det.ymax - det.ymin)
+        if size > largest_size:
+            largest_size = size
+            largest_det = det
+    det = largest_det
+    ${DEBUG}node.warn(f"Detected ({det.xmin}, {det.ymin}) ({det.xmax}, {det.ymax})")
+    ${RESIZE}
+    if new_xmin < 0: new_xmin = 0.001
+    if new_ymin < 0: new_ymin = 0.001
+    if new_xmax > 1: new_xmax = 0.999
+    if new_ymax > 1: new_ymax = 0.999
+
+    ${DEBUG}node.warn(f"New ({new_xmin}, {new_ymin}) ({new_xmax}, {new_ymax})")
+    ${DENORMALIZE}
+    ${DEBUG}node.warn(f"Denormalized START ({startx}, {starty}) Width: {new_width}, height: {new_height})")
+    control = CameraControl(1)
+    ${CONTROL}
+    node.io['control'].send(control)


### PR DESCRIPTION
added option to control the camera component (auto-focus and auto-exposure) with nn detection results.
## Code sample
```
from depthai_sdk import OakCamera

with OakCamera() as oak:
    color = oak.create_camera('color')
    face_det = oak.create_nn('face-detection-retail-0004', color)
    # Control the camera's exposure/focus based on the (largest) detected face
    color.control_with_nn(face_det, auto_focus=True, auto_exposure=True, debug=False)

    oak.visualize(face_det, fps=True)
    oak.start(blocking=True)
```
## Demo
![image](https://github.com/luxonis/depthai/assets/18037362/6b9a4ab1-9d39-4751-a905-4c47f36c8fdf)
**Left**: default AF/AE. **Right**: AF/AE on detected face (code sample above)