### PR TITLE
Added support for 2stage NNs to use all resize modes for detection 

### DIFF
--- a/depthai_sdk/src/depthai_sdk/components/multi_stage_nn.py
+++ b/depthai_sdk/src/depthai_sdk/components/multi_stage_nn.py
@@ -2,7 +2,7 @@ import os
 from pathlib import Path
 from string import Template
 from typing import Tuple, Optional, List
-
+from depthai_sdk.classes.enum import ResizeMode
 import depthai as dai
 
 from depthai_sdk.types import GenericNeuralNetwork
@@ -14,6 +14,9 @@ class MultiStageNN:
                  detection_node: GenericNeuralNetwork,  # Object detection node
                  high_res_frames: dai.Node.Output,
                  size: Tuple[int, int],
+                 frame_size: Tuple[int, int],
+                 det_nn_size: Tuple[int, int],
+                 resize_mode: ResizeMode,
                  num_frames_pool: int = 20,
                  ) -> None:
         """
@@ -21,10 +24,30 @@ class MultiStageNN:
             pipeline (dai.Pipeline): Pipeline object
             detection_node (GenericNeuralNetwork): Object detection NN
             high_res_frames (dai.Node.Output): Frames corresponding to the detection NN
-            size (Tuple[int, int]): Size of the frames.
+            size (Tuple[int, int]): NN input size of the second stage NN
+            frame_size (Tuple[int, int]): Frame size of the first (detection) stage NN
+            det_nn_size (Tuple[int, int]): NN input size of the first (detection) stage NN
+            resize_mode (ResizeMode): Resize mode that was used to resize frame for first (detection) stage
             debug (bool, optional): Enable debug mode. Defaults to False.
             num_frames_pool (int, optional): Number of frames to keep in the pool. Defaults to 20.
         """
+        frame_size_ar = frame_size[0] / frame_size[1]
+        det_nn_size_ar = det_nn_size[0] / det_nn_size[1]
+        if resize_mode == ResizeMode.LETTERBOX:
+            padding = (frame_size_ar - det_nn_size_ar) / 2
+            if padding > 0:
+                self.init = f"xmin = 0; ymin = {-padding}; xmax = 1; ymax = {1 + padding}"
+            else:
+                self.init = f"xmin = {padding}; ymin = 0; xmax = {1 - padding}; ymax = 1"
+        elif resize_mode in [ResizeMode.CROP, ResizeMode.FULL_CROP]:
+            cropping = (1 - (det_nn_size_ar / frame_size_ar)) / 2
+            if cropping < 0:
+                self.init = f"xmin = 0; ymin = {-cropping}; xmax = 1; ymax = {1 + cropping}"
+            else:
+                self.init = f"xmin = {cropping}; ymin = 0; xmax = {1 - cropping}; ymax = 1"
+        else: # Stretch
+            self.init = f"xmin=0; ymin=0; xmax=1; ymax=1"
+
         self.script: dai.node.Script = pipeline.create(dai.node.Script)
         self.script.setProcessor(dai.ProcessorType.LEON_CSS)  # More stable
         self._size: Tuple[int, int] = size
@@ -61,6 +84,7 @@ class MultiStageNN:
                 CHECK_LABELS=f"if det.label not in {str(whitelist_labels)}: continue" if whitelist_labels else "",
                 WIDTH=str(self._size[0]),
                 HEIGHT=str(self._size[1]),
+                INIT=self.init,
                 SCALE_BB_XMIN=f"-{scale_bb[0] / 100}" if scale_bb else "",  # % to float value
                 SCALE_BB_YMIN=f"-{scale_bb[1] / 100}" if scale_bb else "",
                 SCALE_BB_XMAX=f"+{scale_bb[0] / 100}" if scale_bb else "",


### PR DESCRIPTION
Previously only cropping was supported.

Now letterboxing/stretch work as well, examples below:

### Letterbox

https://github.com/luxonis/depthai/assets/18037362/422f950e-98d1-4932-923f-3e483e4e32b9

### Stretch

https://github.com/luxonis/depthai/assets/18037362/bd943f74-1f09-4b81-a40c-0faea2b2a39d

