### PR TITLE
Support for non-standard devices

### DIFF
--- a/depthai_sdk/examples/CameraComponent/preview_all_cameras.py
+++ b/depthai_sdk/examples/CameraComponent/preview_all_cameras.py
@@ -1,6 +1,6 @@
 from depthai_sdk import OakCamera
 
 with OakCamera() as oak:
-    cams = oak.create_all_cameras()
+    cams = oak.create_all_cameras(resolution='max')
     oak.visualize(cams)
     oak.start(blocking=True)

--- a/depthai_sdk/src/depthai_sdk/components/camera_component.py
+++ b/depthai_sdk/src/depthai_sdk/components/camera_component.py
@@ -17,7 +17,7 @@ class CameraComponent(Component):
     def __init__(self,
                  device: dai.Device,
                  pipeline: dai.Pipeline,
-                 source: Union[str, dai.CameraBoardSocket],
+                 source: dai.CameraBoardSocket,
                  resolution: Optional[Union[
                      str, dai.ColorCameraProperties.SensorResolution, dai.MonoCameraProperties.SensorResolution
                  ]] = None,

--- a/depthai_sdk/src/depthai_sdk/components/camera_component.py
+++ b/depthai_sdk/src/depthai_sdk/components/camera_component.py
@@ -23,6 +23,7 @@ class CameraComponent(Component):
                  ]] = None,
                  fps: Optional[float] = None,
                  encode: Union[None, str, bool, dai.VideoEncoderProperties.Profile] = None,
+                 sensor_type: Optional[dai.CameraSensorType] = None,
                  rotation: Optional[int] = None,
                  replay: Optional[Replay] = None,
                  name: Optional[str] = None,
@@ -39,6 +40,7 @@ class CameraComponent(Component):
             resolution (optional): Camera resolution, eg. '800p' or '4k'
             fps (float, optional): Camera FPS
             encode: Encode streams before sending them to the host. Either True (use default), or mjpeg/h264/h265
+            sensor_type: To force color/mono/tof camera
             rotation (int, optional): Rotate the camera by 90, 180, 270 degrees
             replay (Replay object): Replay object to use for mocking the camera
             name (str, optional): Name of the output stream
@@ -47,6 +49,7 @@ class CameraComponent(Component):
         super().__init__()
         self.out = self.Out(self)
         self._pipeline = pipeline
+        self._device = device
 
         self.node: Optional[Union[dai.node.ColorCamera, dai.node.MonoCamera, dai.node.XLinkIn]] = None
         self.encoder: Optional[dai.node.VideoEncoder] = None
@@ -55,6 +58,7 @@ class CameraComponent(Component):
         self.stream_size: Optional[Tuple[int, int]] = None  # Output size
 
         self._source = str(source)
+        self._socket = source
         self._replay: Optional[Replay] = replay
         self._args: Dict = args
         self.name = name
@@ -91,44 +95,22 @@ class CameraComponent(Component):
         # Livestreaming, not replay
         else:
             node_type: dai.node = None
-            if isinstance(source, str):
-                source = source.upper()
-                # When sensors can be either color or mono (eg. AR0234), we allow specifying it
-                if "," in source:  # For sensors that support multiple
-                    parts = source.split(',')
-                    source = parts[0]
-                    if parts[1] in ["C", "COLOR"]:
-                        node_type = dai.node.ColorCamera
-                    elif parts[1] in ["M", "MONO"]:
-                        node_type = dai.node.MonoCamera
-                    else:
-                        raise Exception(
-                            "Please specify sensor type with c/color or m/mono after the ','"
-                            " - eg. `cam = oak.create_camera('cama,c')`"
-                        )
-                elif source in ["COLOR", "RGB"]:
-                    for features in device.getConnectedCameraFeatures():
-                        if dai.CameraSensorType.COLOR in features.supportedTypes:
-                            source = features.socket
-                            break
-                    if not isinstance(source, dai.CameraBoardSocket):
-                        raise ValueError("Couldn't find a color camera!")
+            sensors = [f for f in device.getConnectedCameraFeatures() if f.socket == source]
+            if len(sensors) == 0:
+                raise Exception(f"No camera found on user-specified socket {source}")
+            sensor = sensors[0]
 
-            socket = parse_camera_socket(source)
-            sensor = [f for f in device.getConnectedCameraFeatures() if f.socket == socket][0]
-
-            if node_type is None:  # User specified camera type
-                type = sensor.supportedTypes[0]
-                if type == dai.CameraSensorType.COLOR:
-                    node_type = dai.node.ColorCamera
-                elif type == dai.CameraSensorType.MONO:
-                    node_type = dai.node.MonoCamera
-                else:
-                    raise Exception(f"{sensor} doesn't support either COLOR or MONO ")
+            sensor_type = sensor_type or sensor.supportedTypes[0]
+            if sensor_type == dai.CameraSensorType.COLOR:
+                node_type = dai.node.ColorCamera
+            elif sensor_type == dai.CameraSensorType.MONO:
+                node_type = dai.node.MonoCamera
+            else:
+                raise Exception(f"{sensor} doesn't support either COLOR or MONO ")
 
             # Create the node, and set the socket
             self.node = pipeline.create(node_type)
-            self.node.setBoardSocket(socket)
+            self.node.setBoardSocket(source)
 
         self._resolution_forced: bool = resolution is not None
         if resolution:
@@ -385,7 +367,12 @@ class CameraComponent(Component):
 
     def _set_resolution(self, resolution):
         if not self.is_replay():
-            self.node.setResolution(parse_resolution(type(self.node), resolution))
+            if isinstance(resolution, str) and resolution.lower() in ['max', 'maximum']:
+                sensor = [f for f in self._device.getConnectedCameraFeatures() if f.socket == self._socket][0]
+                resolution = get_max_resolution(sensor)
+            else:
+                resolution = parse_resolution(type(self.node), resolution)
+            self.node.setResolution(resolution)
         # TODO: support potentially downscaling depthai-recording
 
     def is_replay(self) -> bool:

--- a/depthai_sdk/src/depthai_sdk/components/camera_helper.py
+++ b/depthai_sdk/src/depthai_sdk/components/camera_helper.py
@@ -1,6 +1,6 @@
 import math
 import depthai as dai
-from typing import *
+from typing import List, Tuple, Dict, Any, Optional, Union
 import numpy as np
 import cv2
 
@@ -165,6 +165,16 @@ def setCameraControl(control: dai.CameraControl,
 
     # TODO: Add contrast, exposure compensation, brightness, manual exposure, and saturation
 
+
+def get_max_resolution(sensor: dai.CameraFeatures) -> Union[dai.ColorCameraProperties.SensorResolution, dai.MonoCameraProperties.SensorResolution]:
+    max_res = None
+    max_num = 0
+    for conf in sensor.configs:
+        (res, size) = get_sensor_resolution(conf.type, conf.width, conf.height)
+        if size[0] * size[1] > max_num:
+            max_num = size[0] * size[1]
+            max_res = res
+    return max_res
 
 def get_sensor_resolution(type: dai.CameraSensorType, width: int, height: int) -> Tuple[Union[dai.ColorCameraProperties.SensorResolution, dai.MonoCameraProperties.SensorResolution], Tuple[int,int]]:
     def get_res(resolutions: Dict[Any, Tuple[int,int]]):

--- a/depthai_sdk/src/depthai_sdk/components/nn_component.py
+++ b/depthai_sdk/src/depthai_sdk/components/nn_component.py
@@ -36,7 +36,7 @@ class NNComponent(Component):
                  nn_type: Optional[str] = None,  # Either 'yolo' or 'mobilenet'
                  decode_fn: Optional[Callable] = None,
                  tracker: bool = False,  # Enable object tracker - only for Object detection models
-                 spatial: Union[None, bool, StereoComponent] = None,
+                 spatial: Optional[StereoComponent] = None,
                  replay: Optional[Replay] = None,
                  args: Dict = None,  # User defined args
                  name: Optional[str] = None
@@ -97,7 +97,7 @@ class NNComponent(Component):
 
         self._input_queue = Optional[None]  # Input queue for multi-stage pipeline
 
-        self._spatial: Optional[Union[bool, StereoComponent]] = spatial
+        self._spatial: Optional[StereoComponent] = spatial
         self._replay: Optional[Replay] = replay  # Replay module
 
         # For visualizer
@@ -208,12 +208,9 @@ class NNComponent(Component):
             )
 
         if self._spatial:
-            if isinstance(self._spatial, bool):  # Create new StereoComponent
-                self._spatial = StereoComponent(device, pipeline, args=self._args, replay=self._replay)
-            if isinstance(self._spatial, StereoComponent):
-                self._stereo_node: dai.node.StereoDepth = self._spatial.node
-                self._spatial.depth.link(self.node.inputDepth)
-                self._spatial.config_stereo(align=self._input)
+            self._stereo_node: dai.node.StereoDepth = self._spatial.node
+            self._spatial.depth.link(self.node.inputDepth)
+            self._spatial.config_stereo(align=self._input)
             # Configure Spatial Detection Network
 
         if self._args:

--- a/depthai_sdk/src/depthai_sdk/components/parser.py
+++ b/depthai_sdk/src/depthai_sdk/components/parser.py
@@ -70,6 +70,14 @@ def parse_bool(value: str) -> bool:
         raise ValueError(f"Couldn't parse '{value}' to bool!")
 
 
+def get_first_color_cam(device: dai.Device) -> dai.CameraBoardSocket:
+    for cam in device.getConnectedCameraFeatures():
+        if cam.supportedTypes[0] == dai.CameraSensorType.COLOR:
+            return cam.socket
+    # Default
+    return dai.CameraBoardSocket.CAM_A
+
+
 def parse_camera_socket(value: Union[str, dai.CameraBoardSocket]) -> dai.CameraBoardSocket:
     if isinstance(value, dai.CameraBoardSocket):
         return value

--- a/depthai_sdk/src/depthai_sdk/components/pointcloud_component.py
+++ b/depthai_sdk/src/depthai_sdk/components/pointcloud_component.py
@@ -42,10 +42,6 @@ class PointcloudComponent(Component):
 
         self._replay: Optional[Replay] = replay
 
-        # Colorization aspect
-        if colorize is None:
-            self.colorize_comp = CameraComponent(device, pipeline, source='color', replay=replay, args=args)
-
         if isinstance(self.colorize_comp, CameraComponent):
             self.colorize_comp.config_color_camera(isp_scale=(2,5))
 

--- a/depthai_sdk/src/depthai_sdk/components/stereo_component.py
+++ b/depthai_sdk/src/depthai_sdk/components/stereo_component.py
@@ -47,8 +47,6 @@ class StereoComponent(Component):
                  pipeline: dai.Pipeline,
                  left: Union[CameraComponent, dai.node.MonoCamera],  # Left stereo camera
                  right: Union[CameraComponent, dai.node.MonoCamera],  # Right stereo camera
-                 resolution: Union[None, str, dai.MonoCameraProperties.SensorResolution] = None,
-                 fps: Optional[float] = None,
                  replay: Optional[Replay] = None,
                  args: Any = None,
                  name: Optional[str] = None,
@@ -78,8 +76,6 @@ class StereoComponent(Component):
 
         self._device = device
         self._replay: Optional[Replay] = replay
-        self._resolution: Optional[Union[str, dai.MonoCameraProperties.SensorResolution]] = resolution
-        self._fps: Optional[float] = fps
         self._args: Dict = args
         self.name = name
 
@@ -119,25 +115,6 @@ class StereoComponent(Component):
             # Live stream, check whether we have correct cameras
             if len(device.getCameraSensorNames()) == 1:
                 raise Exception('OAK-1 camera does not have Stereo camera pair!')
-
-            # If not specified, default to 400P resolution for faster processing
-            self._resolution = self._resolution or dai.MonoCameraProperties.SensorResolution.THE_400_P
-
-            # Always use 1200p for OAK-D-LR and OAK-D-SR
-            if self._device.getDeviceName() == 'OAK-D-LR':
-                self._resolution = dai.MonoCameraProperties.SensorResolution.THE_1200_P
-
-            if not self.left: # Should never happen
-                self.left = CameraComponent(device, pipeline, 'left', self._resolution, self._fps, replay=self._replay)
-            if not self.right:
-                self.right = CameraComponent(device, pipeline, 'right', self._resolution, self._fps,
-                                             replay=self._replay)
-
-            # AR0234 outputs 1200p, so we need to resize it to 800p on RVC2
-            if self._device.getDeviceName() == 'OAK-D-LR':
-                if isinstance(self.left, CameraComponent) and isinstance(self.right, CameraComponent):
-                    self.left.config_color_camera(isp_scale=(2, 3))
-                    self.right.config_color_camera(isp_scale=(2, 3))
 
             if self._get_ir_drivers():
                 laser = self._args.get('irDotBrightness', None)

--- a/depthai_sdk/src/depthai_sdk/components/stereo_component.py
+++ b/depthai_sdk/src/depthai_sdk/components/stereo_component.py
@@ -45,10 +45,10 @@ class StereoComponent(Component):
     def __init__(self,
                  device: dai.Device,
                  pipeline: dai.Pipeline,
+                 left: Union[CameraComponent, dai.node.MonoCamera],  # Left stereo camera
+                 right: Union[CameraComponent, dai.node.MonoCamera],  # Right stereo camera
                  resolution: Union[None, str, dai.MonoCameraProperties.SensorResolution] = None,
                  fps: Optional[float] = None,
-                 left: Union[None, CameraComponent, dai.node.MonoCamera] = None,  # Left mono camera
-                 right: Union[None, CameraComponent, dai.node.MonoCamera] = None,  # Right mono camera
                  replay: Optional[Replay] = None,
                  args: Any = None,
                  name: Optional[str] = None,

--- a/depthai_sdk/src/depthai_sdk/oak_camera.py
+++ b/depthai_sdk/src/depthai_sdk/oak_camera.py
@@ -287,15 +287,14 @@ class OakCamera:
             name (str): Name used to identify the X-out stream. This name will also be associated with the frame in the callback function.
             encode (bool/str/Profile): Whether we want to enable video encoding (accessible via StereoComponent.out.encoded). If True, it will use h264 codec.
         """
+        calib = self.device.readCalibration2()
         if left is None:
-            left = self.camera(source=dai.CameraBoardSocket.LEFT, resolution=resolution, fps=fps)
+            left = self.camera(source=calib.getStereoLeftCameraId(), resolution=resolution, fps=fps)
         if right is None:
-            right = self.camera(source=dai.CameraBoardSocket.RIGHT, resolution=resolution, fps=fps)
+            right = self.camera(source=calib.getStereoRightCameraId(), resolution=resolution, fps=fps)
 
         comp = StereoComponent(self._oak.device,
                                self.pipeline,
-                               resolution=resolution,
-                               fps=fps,
                                left=left,
                                right=right,
                                replay=self.replay,


### PR DESCRIPTION
A few fixes:
- When creating `color` camera, it will take first color sensor, which fixes many issues for eg. OAK-D-SR
- Auto-downscale stereo frames if they're above 1280pixels in width; fixes issues with OAK-D-LR
- Select stereoLeft camera when creating `left` camera, and stereoRight when creating `right` camera. This could fix some issues with custom devices, or FFC setups, where left/right aren't cam_b/cam_c ports
- In CameraComponent, added option for `resolution='max'`, whcih will set max supported camera resolution

TODO:
- When PR: https://github.com/luxonis/depthai-python/pull/862 gets to mainline, SDK can use `Camera` node instead of `ColorCamera`/`MonoCamera` nodes.
