### PR TITLE
Fix getClosestVideoSize for encoder input

### DIFF
--- a/depthai_sdk/src/depthai_sdk/components/camera_component.py
+++ b/depthai_sdk/src/depthai_sdk/components/camera_component.py
@@ -152,7 +152,7 @@ class CameraComponent(Component):
                 self.node.setIspScale(*scale)
 
             curr_size = self.node.getVideoSize()
-            closest = getClosestVideoSize(*curr_size)
+            closest = getClosestVideoSize(*curr_size, videoEncoder=encode)
             self.node.setVideoSize(*closest)
             self.node.setVideoNumFramesPool(2)  # We will increase it later if we are streaming to host
 

--- a/depthai_sdk/src/depthai_sdk/components/camera_helper.py
+++ b/depthai_sdk/src/depthai_sdk/components/camera_helper.py
@@ -51,15 +51,12 @@ def getClosestVideoSize(width: int, height: int, videoEncoder: bool=False) -> Tu
     """
     For colorCamera.video output
     """
-    while True:
-        if width % 2 == 0: # YUV420/NV12 width needs to be an even number to be convertible to BGR on host using cv2
-            if not videoEncoder or width % 32 == 0: # VideoEncoder HW limitation - width must be divisible by 32
-                break
-        width -= 1
-    while True:
-        if height % 2 == 0: # YUV420/NV12 height needs to be an even number to be convertible to BGR on host using cv2
-            break
-        height -= 1
+    width_divider = 32 if videoEncoder else 2
+    width = (width // width_divider) * width_divider
+
+    height_divider = 8 if videoEncoder else 2
+    height = (height // height_divider) * height_divider
+
     return (width, height)
 
 


### PR DESCRIPTION
- H26x encoder needs height to be divisible by 8
- Replaced while loops with division