### PR TITLE
Fix depthai_sdk/examples/IMUComponent/imu.py: remove wrong arg in oak.visualize() call

### DIFF
--- a/depthai_sdk/examples/IMUComponent/imu.py
+++ b/depthai_sdk/examples/IMUComponent/imu.py
@@ -5,5 +5,5 @@ with OakCamera() as oak:
     imu.config_imu(report_rate=400, batch_report_threshold=5)
     # DepthAI viewer should open, and IMU data can be viewed on the right-side panel,
     # under "Stats" tab (right of the "Device Settings" tab).
-    oak.visualize(imu.out.main, visualizer='viewer')
+    oak.visualize(imu.out.main)
     oak.start(blocking=True)


### PR DESCRIPTION
Tiny PR to fix the call to oak.visualize() is [depthai_sdk/examples/IMUComponent/imu.py#L8](https://github.com/luxonis/depthai/blob/5fb3c41652e20652047dc632221d591d9e8087e7/depthai_sdk/examples/IMUComponent/imu.py#L8) which was producing this error:

```shell
$ python depthai_sdk/examples/IMUComponent/imu.py
Closing OAK camera
Traceback (most recent call last):
  File "/Users/arnlen/depthai/depthai_sdk/examples/IMUComponent/imu.py", line 8, in <module>
    oak.visualize(imu.out.main, visualizer='viewer')
TypeError: OakCamera.visualize() got an unexpected keyword argument 'visualizer'
```

Removing the arg `visualizer='viewer'` fixed it. ✅ 
