### PR TITLE
Change queue size to 1

### DIFF
--- a/depthai_sdk/src/depthai_sdk/oak_camera.py
+++ b/depthai_sdk/src/depthai_sdk/oak_camera.py
@@ -503,7 +503,7 @@ class OakCamera:
 
         for xlink_name in self._new_msg_callbacks:
             try:
-                self.device.getOutputQueue(xlink_name, maxSize=4, blocking=False).addCallback(self._new_oak_msg)
+                self.device.getOutputQueue(xlink_name, maxSize=1, blocking=False).addCallback(self._new_oak_msg)
             # TODO: make this nicer, have self._new_msg_callbacks know whether it's replay or not
             except Exception as e:
                 if self.replay:


### PR DESCRIPTION
Having a queue bigger than one in case only callbacks are used is only "wasting" memory, since no one ever uses the messages in the queue.