### PR TITLE
Allow use of prior cached model

### DIFF
--- a/depthai_sdk/src/depthai_sdk/integrations/roboflow.py
+++ b/depthai_sdk/src/depthai_sdk/integrations/roboflow.py
@@ -27,15 +27,17 @@ class RoboflowIntegration:
 
     def device_update(self, device: dai.Device) -> Path:
         mxid = device.getMxId()
-        url = f"https://api.roboflow.com/depthai/{self.config['model']}/?api_key={self.config['key']}&device={mxid}"
-        response = requests.get(url)
-
         name = self.config['model'].replace('/', '_')  # '/' isn't valid folder name
 
         model_folder = ROBOFLOW_MODELS / name
         json_file = self._file_with_ext(model_folder, '.json')
         if json_file:
             return json_file
+
+        #Check the URL after checking the cache to make sure vision systems that are offline don't throw an exception
+        url = f"https://api.roboflow.com/depthai/{self.config['model']}/?api_key={self.config['key']}&device={mxid}"
+        response = requests.get(url)
+
 
         json_res = response.json()
         if "error" in json_res:


### PR DESCRIPTION
Moving the requests.get(url) below the check for the cache.  If your vision system is offline, and you have a cached model, the call to requests prior to checking the cache throws an exception.  Now if you have a cached model it will use that first and only if you do not have a model will it switch to checking api.roboflow.com