### PR TITLE
Fix order in Update ai_models.rst

### DIFF
--- a/depthai_sdk/docs/source/features/ai_models.rst
+++ b/depthai_sdk/docs/source/features/ai_models.rst
@@ -57,8 +57,8 @@ The following table lists all the models supported by the SDK. The model name is
      - `DMZ <https://github.com/luxonis/depthai-model-zoo/tree/main/models/facemesh_192x192>`__
      - 32
    * - ``facial_landmarks_68_160x160``
-     - 32
      - `DMZ <https://github.com/luxonis/depthai-model-zoo/blob/main/models/facial_landmarks_68_160x160>`__
+     - 32
    * - ``human-pose-estimation-0001``
      - `OMZ <https://docs.openvino.ai/2022.1/omz_models_model_human_pose_estimation_0001.html>`__
      - 8


### PR DESCRIPTION
There was an order error in columns for model `facial_landmarks_68_160x160`, this Pull Request fixes it.

![Screenshot from 2024-05-20 12-02-00](https://github.com/luxonis/depthai/assets/57449233/8165c8a3-affc-487d-a5af-7964c9f908d0)
