### PR TITLE
Add that default calibrate.py uses the stereoUseSpecTranslation = False

### DIFF
--- a/calibrate.py
+++ b/calibrate.py
@@ -1045,6 +1045,8 @@ class Main:
                                         self.args.squaresY,
                                         self.args.cameraMode,
                                         self.args.rectifiedDisp) # Turn off enable disp rectify
+            if status == -1:
+                raise RuntimeError(f"Calibration failed: {result_config}")
 
             if self.args.noInitCalibration or self.args.debugProcessingMode:
                 calibration_handler = dai.CalibrationHandler()
@@ -1150,6 +1152,10 @@ class Main:
                 # print(calib_dest_path)
 
                 eeepromData = calibration_handler.getEepromData()
+                eeepromData.stereoUseSpecTranslation = False
+                eeepromData.stereoEnableDistortionCorrection = True
+
+                calibration_handler = dai.CalibrationHandler(eeepromData)
                 print(f'EEPROM VERSION being flashed is  -> {eeepromData.version}')
                 eeepromData.version = 7
                 print(f'EEPROM VERSION being flashed is  -> {eeepromData.version}')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 requests==2.26.0
 --extra-index-url https://www.piwheels.org/simple
 numpy>=1.21.4,<2.0.0 # For RPi Buster (last successful build) and macOS M1 (first build). But allow for higher versions, to support Python3.11 (not available in 1.21.4 yet)
+opencv-python==4.5.5.62 # Last successful RPi build, also covers M1 with above pinned numpy (otherwise 4.6.0.62 would be required, but that has a bug with charuco boards). Python version not important, abi3 wheels
 opencv-contrib-python==4.5.5.62 # Last successful RPi build, also covers M1 with above pinned numpy (otherwise 4.6.0.62 would be required, but that has a bug with charuco boards). Python version not important, abi3 wheels
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-depthai-data-local/wheels/
 pyqt5>5,<5.15.6 ; platform_machine != "armv6l" and platform_machine != "armv7l" and platform_machine != "aarch64" and platform_machine != "arm64"


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO
